### PR TITLE
Skip empty sections of the VLQ

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -131,6 +131,10 @@ fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
     let mut tokens = Vec::with_capacity(allocation_size);
 
     for (dst_line, line) in mappings.split(';').enumerate() {
+        if line.len() == 0 {
+            continue;
+        }
+        
         dst_col = 0;
 
         for segment in line.split(',') {


### PR DESCRIPTION
This diff shaves around 5% off sourcemapping large files by eagerly skipping empty lines.