### PR TITLE
fix: Regression when source files are null

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -85,7 +85,7 @@ impl Encodable for SourceMap {
         RawSourceMap {
             version: Some(3),
             file: self.get_file().map(|x| Value::String(x.to_string())),
-            sources: Some(self.sources().map(|x| x.to_string()).collect()),
+            sources: Some(self.sources().map(|x| Some(x.to_string())).collect()),
             // XXX: consider setting this to common root
             source_root: None,
             sources_content: if have_contents { Some(contents) } else { None },

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -20,7 +20,7 @@ pub struct RawSourceMap {
     pub version: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<Value>,
-    pub sources: Option<Vec<String>>,
+    pub sources: Option<Vec<Option<String>>>,
     #[serde(rename = "sourceRoot", skip_serializing_if = "Option::is_none")]
     pub source_root: Option<String>,
     #[serde(rename = "sourcesContent", skip_serializing_if = "Option::is_none")]

--- a/tests/test_decoder.rs
+++ b/tests/test_decoder.rs
@@ -125,3 +125,19 @@ fn test_sourcemap_data_url() {
         }
     }
 }
+
+#[test]
+fn test_sourcemap_nofiles() {
+    let input: &[_] = b"{
+        \"version\":3,
+        \"sources\":[null],
+        \"names\":[\"x\",\"alert\"],
+        \"mappings\":\"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM\"
+    }";
+    let sm = SourceMap::from_reader(input).unwrap();
+    let mut iter = sm.tokens().filter(|t| t.has_name());
+    assert_eq!(iter.next().unwrap().to_tuple(), ("", 0, 4, Some("x")));
+    assert_eq!(iter.next().unwrap().to_tuple(), ("", 1, 4, Some("x")));
+    assert_eq!(iter.next().unwrap().to_tuple(), ("", 2, 2, Some("alert")));
+    assert!(iter.next().is_none());
+}


### PR DESCRIPTION
This regression likely occurred with the move from serde 0.9 to 1.0. I suppose that it used to consider defaultable values optional and coerce null into default.

Anyway, I didn't want to change too much, so the only thing that has changed is that sources are now optional. This was actually uncovered by a test in sentry, which is now ported over to this repo.