### PR TITLE
Propagate cfg guards from rust-url

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(any(unix, windows, target_os = "redox")), allow(unused_imports))]
+
 use std::collections::HashMap;
 use std::convert::AsRef;
 use std::env;
@@ -25,6 +27,7 @@ pub struct SourceMapBuilder {
     source_contents: Vec<Option<String>>,
 }
 
+#[cfg(any(unix, windows, target_os = "redox"))]
 fn resolve_local_reference(base: &Url, reference: &str) -> Option<PathBuf> {
     let url = match base.join(reference) {
         Ok(url) => {
@@ -109,6 +112,7 @@ impl SourceMapBuilder {
 
     /// Loads source contents from locally accessible files if referenced
     /// accordingly.  Returns the number of loaded source contents
+    #[cfg(any(unix, windows, target_os = "redox"))]
     pub fn load_local_source_contents(&mut self, base_path: Option<&Path>) -> Result<usize> {
         let mut abs_path = env::current_dir()?;
         if let Some(path) = base_path {

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,6 +25,7 @@ pub struct RewriteOptions<'a> {
     pub with_source_contents: bool,
     /// If enabled local source contents that are not in the
     /// file are automatically inlined.
+    #[cfg(any(unix, windows, target_os = "redox"))]
     pub load_local_source_contents: bool,
     /// The base path to the used for source reference resolving
     /// when loading local source contents is used.
@@ -40,6 +41,7 @@ impl<'a> Default for RewriteOptions<'a> {
         RewriteOptions {
             with_names: true,
             with_source_contents: true,
+            #[cfg(any(unix, windows, target_os = "redox"))]
             load_local_source_contents: false,
             base_path: None,
             strip_prefixes: &[][..],
@@ -730,8 +732,12 @@ impl SourceMap {
                     .set_source_contents(raw.src_id, self.get_source_contents(token.get_src_id()));
             }
         }
-        if options.load_local_source_contents {
-            builder.load_local_source_contents(options.base_path)?;
+
+        #[cfg(any(unix, windows, target_os = "redox"))]
+        {
+            if options.load_local_source_contents {
+                builder.load_local_source_contents(options.base_path)?;
+            }
         }
 
         let mut prefixes = vec![];


### PR DESCRIPTION
Guard APIs that depend on `Url::to_file_path` and `Url::from_directory_path` on the same platforms as rust-url.

This allows to compile rust-sourcemap on other platforms (e.g. `wasm32-unknown-unknown`) without errors.