### PR TITLE
fix: Rename cyclomatic_complexity to cognitive_complexity.

### DIFF
--- a/src/sourceview.rs
+++ b/src/sourceview.rs
@@ -323,7 +323,7 @@ impl<'a> SourceView<'a> {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn test_minified_source_view() {
     let view = SourceView::new("a\nb\nc");
     assert_eq!(view.get_line(0), Some("a"));


### PR DESCRIPTION
Changed in Rust 1.35.

https://github.com/rust-lang/rust-clippy/blob/ba6681300e9d7a10379c9fbbf539f4f3261fdc6a/CHANGELOG.md#rust-135

