### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ include = [
 all-features = true
 
 [dependencies]
-url = "1.7.2"
-serde = { version = "1.0.88", features = ["derive"] }
-serde_json = "1.0.38"
-base64 = "0.10.1"
-regex = "1.1.0"
-lazy_static = "1.2.0"
-if_chain = "0.1.3"
-scroll = { version = "0.9.2", features = ["derive"], optional = true }
+url = "2.1.1"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_json = "1.0.48"
+base64 = "0.11.0"
+regex = "1.3.4"
+lazy_static = "1.4.0"
+if_chain = "1.0.0"
+scroll = { version = "0.10.1", features = ["derive"], optional = true }
 
 [build-dependencies]
 rustc_version = "0.2.3"


### PR DESCRIPTION
sourcemap is causing us to have multiple versions of the URL crate downstream.