### PR TITLE
feat: Minimal API changes to source map references

### DIFF
--- a/src/hermes.rs
+++ b/src/hermes.rs
@@ -11,12 +11,14 @@ use std::ops::{Deref, DerefMut};
 /// These are starting locations of scopes.
 /// The `name_index` represents the index into the `HermesFunctionMap.names` vec,
 /// which represents the function names/scopes.
+#[derive(Debug, Clone)]
 pub struct HermesScopeOffset {
     line: u32,
     column: u32,
     name_index: u32,
 }
 
+#[derive(Debug, Clone)]
 pub struct HermesFunctionMap {
     names: Vec<String>,
     mappings: Vec<HermesScopeOffset>,
@@ -24,6 +26,7 @@ pub struct HermesFunctionMap {
 
 /// Represents a `react-native`-style SourceMap, which has additional scope
 /// information embedded.
+#[derive(Debug, Clone)]
 pub struct SourceMapHermes {
     pub(crate) sm: SourceMap,
     // There should be one `HermesFunctionMap` per each `sources` entry in the main SourceMap.

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -15,7 +15,7 @@ pub struct RawSection {
     pub map: Option<Box<RawSourceMap>>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct FacebookScopeMapping {
     pub names: Vec<String>,
     pub mappings: String,

--- a/src/sourceview.rs
+++ b/src/sourceview.rs
@@ -6,6 +6,8 @@ use std::str;
 
 use if_chain::if_chain;
 
+use crate::detector::{locate_sourcemap_reference_slice, SourceMapRef};
+use crate::errors::Result;
 use crate::types::{idx_from_token, sourcemap_from_token, Token};
 use crate::utils::{get_javascript_token, is_valid_javascript_identifier};
 
@@ -319,6 +321,11 @@ impl<'a> SourceView<'a> {
     pub fn line_count(&self) -> usize {
         self.get_line(!0);
         self.lines.borrow().len()
+    }
+
+    /// Returns the source map reference in the source view.
+    pub fn sourcemap_reference(&self) -> Result<Option<SourceMapRef>> {
+        locate_sourcemap_reference_slice(self.source.as_bytes())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -274,7 +274,7 @@ impl<'a> Token<'a> {
     }
 
     /// Returns the referenced source view.
-    pub fn source_view(&self) -> Option<&SourceView<'_>> {
+    pub fn get_source_view(&self) -> Option<&SourceView<'_>> {
         self.i.get_source_view(self.get_src_id())
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -272,6 +272,11 @@ impl<'a> Token<'a> {
     pub fn get_raw_token(&self) -> RawToken {
         *self.raw
     }
+
+    /// Returns the referenced source view.
+    pub fn source_view(&self) -> Option<&SourceView<'_>> {
+        self.i.get_source_view(self.get_src_id())
+    }
 }
 
 pub fn idx_from_token(token: &Token<'_>) -> u32 {
@@ -920,7 +925,6 @@ impl SourceMapIndex {
     pub fn lookup_token(&self, line: u32, col: u32) -> Option<Token<'_>> {
         for section in self.sections() {
             let (off_line, off_col) = section.get_offset();
-            println!("off_line: {}, off_col: {}", off_line, off_col);
             if off_line < line || off_col < col {
                 continue;
             }

--- a/tests/test_detector.rs
+++ b/tests/test_detector.rs
@@ -5,11 +5,14 @@ fn test_basic_locate() {
     let input: &[_] = b"foo();\nbar();\n//# sourceMappingURL=foo.js";
     assert_eq!(
         locate_sourcemap_reference(input).unwrap(),
-        SourceMapRef::Ref("foo.js".into())
+        Some(SourceMapRef::Ref("foo.js".into()))
     );
     assert_eq!(
-        locate_sourcemap_reference(input).unwrap().get_url(),
-        Some("foo.js")
+        locate_sourcemap_reference(input)
+            .unwrap()
+            .unwrap()
+            .get_url(),
+        "foo.js"
     );
 }
 
@@ -18,21 +21,21 @@ fn test_legacy_locate() {
     let input: &[_] = b"foo();\nbar();\n//@ sourceMappingURL=foo.js";
     assert_eq!(
         locate_sourcemap_reference(input).unwrap(),
-        SourceMapRef::LegacyRef("foo.js".into())
+        Some(SourceMapRef::LegacyRef("foo.js".into()))
     );
     assert_eq!(
-        locate_sourcemap_reference(input).unwrap().get_url(),
-        Some("foo.js")
+        locate_sourcemap_reference(input)
+            .unwrap()
+            .unwrap()
+            .get_url(),
+        "foo.js"
     );
 }
 
 #[test]
 fn test_no_ref() {
     let input: &[_] = b"foo();\nbar();\n// whatever";
-    assert_eq!(
-        locate_sourcemap_reference(input).unwrap(),
-        SourceMapRef::Missing
-    );
+    assert_eq!(locate_sourcemap_reference(input).unwrap(), None);
 }
 
 #[test]


### PR DESCRIPTION
This is a backwards incompatible change to the crate which adds some missing API and changes how sourcemap references work.

I ran across this trying to use this crate for building a source map debug tool.