### PR TITLE
Conditionally compile SourceMapRef.resolve_path based on target support

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -46,6 +46,7 @@ impl SourceMapRef {
     /// Resolves the reference against a local file path
     ///
     /// This is similar to `resolve` but operates on file paths.
+    #[cfg(any(unix, windows, target_os = "redox"))]
     pub fn resolve_path(&self, minified_path: &Path) -> Option<PathBuf> {
         let url = self.get_url();
         if url.starts_with("data:") {

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1,5 +1,4 @@
 use std::io::{BufRead, BufReader, Read};
-use std::path::{Path, PathBuf};
 use std::str;
 
 use crate::decoder::{decode_data_url, strip_junk_header, StripHeaderReader};
@@ -47,7 +46,7 @@ impl SourceMapRef {
     ///
     /// This is similar to `resolve` but operates on file paths.
     #[cfg(any(unix, windows, target_os = "redox"))]
-    pub fn resolve_path(&self, minified_path: &Path) -> Option<PathBuf> {
+    pub fn resolve_path(&self, minified_path: &std::path::Path) -> Option<std::path::PathBuf> {
         let url = self.get_url();
         if url.starts_with("data:") {
             return None;


### PR DESCRIPTION
This change adds back support for targeting `wasm32-unknown-unknown`. 

```
error[E0599]: no function or associated item named `from_file_path` found for struct `url::Url` in the current scope
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/sourcemap-6.0.0/src/detector.rs:54:32
   |
54 |         resolve_url(url, &Url::from_file_path(&minified_path).ok()?)
   |                                ^^^^^^^^^^^^^^ function or associated item not found in `url::Url`

error[E0599]: no method named `to_file_path` found for struct `url::Url` in the current scope
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/sourcemap-6.0.0/src/detector.rs:55:29
   |
55 |             .and_then(|x| x.to_file_path().ok())
   |                             ^^^^^^^^^^^^ method not found in `url::Url`

error: aborting due to 2 previous errors
```