### PR TITLE
ref(clippy): Derive Eq together with PartialEq

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -11,7 +11,7 @@ use crate::vlq::parse_vlq_segment_into;
 
 const DATA_PREAMBLE: &str = "data:application/json;base64,";
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 enum HeaderState {
     Undecided,
     Junk,

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -9,7 +9,7 @@ use crate::types::DecodedMap;
 use url::Url;
 
 /// Represents a reference to a sourcemap
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum SourceMapRef {
     /// A regular URL reference
     Ref(String),

--- a/src/types.rs
+++ b/src/types.rs
@@ -128,7 +128,7 @@ impl DecodedMap {
 /// in a memory efficient way.  If you construct sourcemaps yourself
 /// then you need to create these objects, otherwise they are invisible
 /// to you as a user.
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct RawToken {
     /// the destination (minified) line number (0-indexed)
     pub dst_line: u32,


### PR DESCRIPTION
Clippy now reckons you should always derive Eq if you already derive
PartialEq since that implementation already fulfils Eq.  I guess
that's fine, unless there's a reason we don't want to commit to Eq on
the public API parts.

#skip-changelog