### PR TITLE
Fix Index source map lookup

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -51,7 +51,7 @@ impl SourceMapRef {
         if url.starts_with("data:") {
             return None;
         }
-        resolve_url(url, &Url::from_file_path(&minified_path).ok()?)
+        resolve_url(url, &Url::from_file_path(minified_path).ok()?)
             .and_then(|x| x.to_file_path().ok())
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -628,10 +628,12 @@ impl SourceMap {
         }
 
         if low > 0 && low <= self.index.len() {
-            self.get_token(self.index[low as usize - 1].2)
-        } else {
-            None
+            let ii = &self.index[low - 1];
+            if line == ii.0 {
+                return self.get_token(ii.2);
+            }
         }
+        None
     }
 
     /// Given a location, name and minified source file resolve a minified

--- a/src/types.rs
+++ b/src/types.rs
@@ -295,11 +295,14 @@ pub struct TokenIter<'a> {
 
 impl<'a> TokenIter<'a> {
     pub fn seek(&mut self, line: u32, col: u32) -> bool {
-        let ii = greatest_lower_bound(&self.i.index, |ii| (line, col).cmp(&(ii.0, ii.1)));
-        ii.map(|ii| {
-            self.next_idx = ii.2 + 1;
-        })
-        .is_some()
+        let token = self.i.lookup_token(line, col);
+        match token {
+            Some(token) => {
+                self.next_idx = token.idx + 1;
+                true
+            }
+            None => false,
+        }
     }
 }
 
@@ -612,13 +615,7 @@ impl SourceMap {
     /// Looks up the closest token to a given 0-indexed line and column.
     pub fn lookup_token(&self, line: u32, col: u32) -> Option<Token<'_>> {
         let ii = greatest_lower_bound(&self.index, |ii| (line, col).cmp(&(ii.0, ii.1)));
-        ii.and_then(|ii| {
-            if line == ii.0 {
-                self.get_token(ii.2)
-            } else {
-                None
-            }
-        })
+        self.get_token(ii.2)
     }
 
     /// Given a location, name and minified source file resolve a minified

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@ use crate::encoder::encode;
 use crate::errors::{Error, Result};
 use crate::hermes::SourceMapHermes;
 use crate::sourceview::SourceView;
-use crate::utils::find_common_prefix;
+use crate::utils::{find_common_prefix, greatest_lower_bound};
 
 /// Controls the `SourceMap::rewrite` behavior
 ///
@@ -1051,22 +1051,5 @@ impl SourceMapSection {
     /// Replaces the embedded sourcemap
     pub fn set_sourcemap(&mut self, sm: Option<DecodedMap>) {
         self.map = sm.map(Box::new);
-    }
-}
-
-fn greatest_lower_bound<'a, T, K: Ord, F: Fn(&'a T) -> K>(
-    slice: &'a [T],
-    key: &K,
-    map: F,
-) -> Option<&'a T> {
-    match slice.binary_search_by_key(key, map) {
-        Ok(index) => Some(&slice[index]),
-        Err(index) => {
-            if index > 0 {
-                Some(&slice[index - 1])
-            } else {
-                None
-            }
-        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -144,6 +144,23 @@ pub fn make_relative_path(base: &str, target: &str) -> String {
     }
 }
 
+pub fn greatest_lower_bound<'a, T, K: Ord, F: Fn(&'a T) -> K>(
+    slice: &'a [T],
+    key: &K,
+    map: F,
+) -> Option<&'a T> {
+    match slice.binary_search_by_key(key, map) {
+        Ok(index) => Some(&slice[index]),
+        Err(index) => {
+            if index > 0 {
+                Some(&slice[index - 1])
+            } else {
+                None
+            }
+        }
+    }
+}
+
 #[test]
 fn test_is_abs_path() {
     assert!(is_abs_path("C:\\foo.txt"));

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -23,7 +23,7 @@ fn test_basic_indexed_sourcemap() {
             {
                 "offset": {
                     "line": 1,
-                    "column": 0
+                    "column": 1
                 },
                 "map": {
                     "version":3,
@@ -95,6 +95,24 @@ fn test_basic_indexed_sourcemap() {
             .unwrap_or_else(|| panic!("no source for {}", filename));
         assert_eq!(&view.lines().collect::<Vec<_>>(), ref_contents);
     }
+
+    assert_eq!(
+        ism.lookup_token(0, 0).unwrap().to_tuple(),
+        ("file1.js", 0, 0, None)
+    );
+    assert_eq!(ism.lookup_token(1, 0), None);
+    assert_eq!(
+        ism.lookup_token(1, 1).unwrap().to_tuple(),
+        ("file2.js", 0, 0, None)
+    );
+    assert_eq!(
+        ism.lookup_token(1, 8).unwrap().to_tuple(),
+        ("file2.js", 0, 0, None)
+    );
+    assert_eq!(
+        ism.lookup_token(1, 9).unwrap().to_tuple(),
+        ("file2.js", 0, 9, Some("multiply"))
+    );
 }
 
 #[test]

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -100,7 +100,10 @@ fn test_basic_indexed_sourcemap() {
         ism.lookup_token(0, 0).unwrap().to_tuple(),
         ("file1.js", 0, 0, None)
     );
-    assert_eq!(ism.lookup_token(1, 0), None);
+    assert_eq!(
+        ism.lookup_token(1, 0).unwrap().to_tuple(),
+        ("file1.js", 2, 12, Some("b"))
+    );
     assert_eq!(
         ism.lookup_token(1, 1).unwrap().to_tuple(),
         ("file2.js", 0, 0, None)

--- a/tests/test_regular.rs
+++ b/tests/test_regular.rs
@@ -1,0 +1,34 @@
+use sourcemap::SourceMap;
+
+#[test]
+fn test_basic_sourcemap() {
+    let input: &[_] = b"{
+        \"version\":3,
+        \"sources\":[\"coolstuff.js\"],
+        \"names\":[\"x\",\"alert\"],
+        \"mappings\":\"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM\"
+    }";
+    let sm = SourceMap::from_reader(input).unwrap();
+
+    assert_eq!(
+        sm.lookup_token(0, 0).unwrap().to_tuple(),
+        ("coolstuff.js", 0, 0, None)
+    );
+    assert_eq!(
+        sm.lookup_token(0, 3).unwrap().to_tuple(),
+        ("coolstuff.js", 0, 4, Some("x"))
+    );
+    assert_eq!(
+        sm.lookup_token(0, 24).unwrap().to_tuple(),
+        ("coolstuff.js", 2, 8, None)
+    );
+
+    // Lines continue out to infinity
+    assert_eq!(
+        sm.lookup_token(0, 1000).unwrap().to_tuple(),
+        ("coolstuff.js", 2, 8, None)
+    );
+
+    // Token must be on the same line to be found.
+    assert_eq!(sm.lookup_token(1000, 0), None);
+}

--- a/tests/test_regular.rs
+++ b/tests/test_regular.rs
@@ -29,6 +29,9 @@ fn test_basic_sourcemap() {
         ("coolstuff.js", 2, 8, None)
     );
 
-    // Token must be on the same line to be found.
-    assert_eq!(sm.lookup_token(1000, 0), None);
+    // Token can return prior lines.
+    assert_eq!(
+        sm.lookup_token(1000, 0).unwrap().to_tuple(),
+        ("coolstuff.js", 2, 8, None)
+    );
 }


### PR DESCRIPTION
I found two bugs while using the package.

1. ~~The last token in a `Regular` map would be returned for very large lookup line numbers.~~ Deferred till later PR
2. The `Index` source map would recurse into section `i`, `i+1`, etc, when it should have recursed into only `i-1`.

~~The first deals with the "greatest lower bound" that the Mozilla Source Map package used. When searching for a token, we want to find the one closest to `(line, col)`, given `(gen_line, gen_col) <= (line, col)`. This means that looking up `(0, 10_000)` should return the last token on line 0 (assuming the generated column is less than 10,000). Effectively, the last segment in a line extends to infinity columns. But, if we look for a very large input line, eg `(10_000, 0)`, we accidentally returned the last token in our map (again, assuming there are less than 10,000 generated lines). That's because that token's position is `<=` our lookup position. This is a break with Mozilla's behavior, where the returned token must be on our lookup line.~~

Similarly, an `Index` map had another bug with the greatest lower bound lookup behavior. Each section's offset behaves the same as a token, where a section map applies for all positions after its offset. So we need to again find a `(off_line, off_col) <= (line, col)`. The old code would find only `(off_line, off_col) > (line, col)` (and then would keep searching beyond!).

Additionally, the lookup column of an `Index` lookup is only subtracted if the lookup line is the same as the section's offset line. Effectively, the section's first line is shifted by `off_col`, but all following lines start at generated column 0.