### PR TITLE
Remove regex dependency for faster runtime, and compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0.48"
 base64 = "0.13.0"
 regex = "1.3.4"
 lazy_static = "1.4.0"
+unicode-id  = "0.3"
 if_chain = "1.0.0"
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,6 @@ url = "2.1.1"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"
 base64 = "0.13.0"
-regex = "1.3.4"
-lazy_static = "1.4.0"
 unicode-id  = "0.3"
 if_chain = "1.0.0"
 scroll = { version = "0.10.1", features = ["derive"], optional = true }

--- a/src/js_identifiers.rs
+++ b/src/js_identifiers.rs
@@ -1,33 +1,4 @@
-use lazy_static::lazy_static;
-use regex::Regex;
 use unicode_id::UnicodeID;
-
-lazy_static! {
-    static ref ANCHORED_IDENT_RE: Regex = Regex::new(
-        r#"(?x)
-            ^
-            \s*
-            ([\d\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}$_]
-            [\d\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}$_]*)
-        "#
-    )
-    .unwrap();
-}
-
-fn is_valid_javascript_identifier_original(s: &str) -> bool {
-    // check explicitly we do not have a dot in this identifier so that
-    // we do not match on foo.bar
-    s.trim() == s && !s.contains('.') && ANCHORED_IDENT_RE.is_match(s)
-}
-
-fn get_javascript_token_original(source_line: &str) -> Option<&str> {
-    if let Some(m) = ANCHORED_IDENT_RE.captures(source_line) {
-        let rng = m.get(1).unwrap();
-        Some(&source_line[rng.start()..rng.end()])
-    } else {
-        None
-    }
-}
 
 /// Returns true if `c` is a valid character for an identifier start.
 fn is_valid_start(c: char) -> bool {
@@ -92,30 +63,18 @@ pub fn get_javascript_token(source_line: &str) -> Option<&str> {
 
 #[test]
 fn test_is_valid_javascript_identifier() {
-    assert_eq!(is_valid_javascript_identifier_original("foo 123"), true);
     // assert_eq!(is_valid_javascript_identifier("foo 123"), true);
-    assert_eq!(is_valid_javascript_identifier_original("foo_$123"), true);
     assert_eq!(is_valid_javascript_identifier("foo_$123"), true);
-    assert_eq!(is_valid_javascript_identifier_original(" foo"), false);
     assert_eq!(is_valid_javascript_identifier(" foo"), false);
-    assert_eq!(is_valid_javascript_identifier_original("foo "), false);
     assert_eq!(is_valid_javascript_identifier("foo "), false);
-    assert_eq!(is_valid_javascript_identifier_original("[123]"), false);
     assert_eq!(is_valid_javascript_identifier("[123]"), false);
-    assert_eq!(is_valid_javascript_identifier_original("foo.bar"), false);
     assert_eq!(is_valid_javascript_identifier("foo.bar"), false);
     // Should these pass?
-    assert_eq!(is_valid_javascript_identifier_original("foo [bar]"), true);
     // assert_eq!(is_valid_javascript_identifier("foo [bar]"), true);
-    assert_eq!(is_valid_javascript_identifier_original("foo[bar]"), true);
     // assert_eq!(is_valid_javascript_identifier("foo[bar]"), true);
 
-    assert_eq!(get_javascript_token_original("foo "), Some("foo"));
     assert_eq!(get_javascript_token("foo "), Some("foo"));
-    assert_eq!(get_javascript_token_original("f _hi"), Some("f"));
     assert_eq!(get_javascript_token("f _hi"), Some("f"));
-    assert_eq!(get_javascript_token_original("foo.bar"), Some("foo"));
     assert_eq!(get_javascript_token("foo.bar"), Some("foo"));
-    assert_eq!(get_javascript_token_original("[foo,bar]"), None);
     assert_eq!(get_javascript_token("[foo,bar]"), None);
 }

--- a/src/js_identifiers.rs
+++ b/src/js_identifiers.rs
@@ -23,7 +23,7 @@ fn is_valid_continue(c: char) -> bool {
     }
 }
 
-fn strip_to_js_token(s: &str) -> Option<&str> {
+fn strip_identifier(s: &str) -> Option<&str> {
     let mut iter = s.char_indices();
     // Is the first character a valid starting character
     match iter.next() {
@@ -49,14 +49,13 @@ fn strip_to_js_token(s: &str) -> Option<&str> {
 }
 
 pub fn is_valid_javascript_identifier(s: &str) -> bool {
-    // check explicitly we do not have a dot in this identifier so that
-    // we do not match on foo.bar
-    !s.contains('.') && strip_to_js_token(s).map_or(0, |t| t.len()) == s.len()
+    // check stripping does not reduce the length of the token
+    strip_identifier(s).map_or(0, |t| t.len()) == s.len()
 }
 
 pub fn get_javascript_token(source_line: &str) -> Option<&str> {
     match source_line.split_whitespace().next() {
-        Some(s) => strip_to_js_token(s),
+        Some(s) => strip_identifier(s),
         None => None,
     }
 }

--- a/src/js_identifiers.rs
+++ b/src/js_identifiers.rs
@@ -1,0 +1,121 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use unicode_id::UnicodeID;
+
+lazy_static! {
+    static ref ANCHORED_IDENT_RE: Regex = Regex::new(
+        r#"(?x)
+            ^
+            \s*
+            ([\d\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}$_]
+            [\d\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}$_]*)
+        "#
+    )
+    .unwrap();
+}
+
+fn is_valid_javascript_identifier_original(s: &str) -> bool {
+    // check explicitly we do not have a dot in this identifier so that
+    // we do not match on foo.bar
+    s.trim() == s && !s.contains('.') && ANCHORED_IDENT_RE.is_match(s)
+}
+
+fn get_javascript_token_original(source_line: &str) -> Option<&str> {
+    if let Some(m) = ANCHORED_IDENT_RE.captures(source_line) {
+        let rng = m.get(1).unwrap();
+        Some(&source_line[rng.start()..rng.end()])
+    } else {
+        None
+    }
+}
+
+/// Returns true if `c` is a valid character for an identifier start.
+fn is_valid_start(c: char) -> bool {
+    c == '$' || c == '_' || c.is_ascii_alphabetic() || {
+        if c.is_ascii() {
+            false
+        } else {
+            UnicodeID::is_id_start(c)
+        }
+    }
+}
+
+/// Returns true if `c` is a valid character for an identifier part after
+/// start.
+fn is_valid_continue(c: char) -> bool {
+    c == '$' || c == '_' || c == '\u{200c}' || c == '\u{200d}' || c.is_ascii_alphanumeric() || {
+        if c.is_ascii() {
+            false
+        } else {
+            UnicodeID::is_id_continue(c)
+        }
+    }
+}
+
+fn strip_to_js_token(s: &str) -> Option<&str> {
+    let mut iter = s.char_indices();
+    // Is the first character a valid starting character
+    match iter.next() {
+        Some((_, c)) => {
+            if !is_valid_start(c) {
+                return None;
+            }
+        }
+        None => {
+            return None;
+        }
+    };
+    // Slice up to the last valid continuation character
+    let mut end_idx = 0;
+    for (i, c) in iter {
+        if is_valid_continue(c) {
+            end_idx = i;
+        } else {
+            break;
+        }
+    }
+    return Some(&s[..=end_idx]);
+}
+
+pub fn is_valid_javascript_identifier(s: &str) -> bool {
+    // check explicitly we do not have a dot in this identifier so that
+    // we do not match on foo.bar
+    !s.contains('.') && strip_to_js_token(s).map_or(0, |t| t.len()) == s.len()
+}
+
+pub fn get_javascript_token(source_line: &str) -> Option<&str> {
+    match source_line.split_whitespace().next() {
+        Some(s) => strip_to_js_token(s),
+        None => None,
+    }
+}
+
+#[test]
+fn test_is_valid_javascript_identifier() {
+    assert_eq!(is_valid_javascript_identifier_original("foo 123"), true);
+    // assert_eq!(is_valid_javascript_identifier("foo 123"), true);
+    assert_eq!(is_valid_javascript_identifier_original("foo_$123"), true);
+    assert_eq!(is_valid_javascript_identifier("foo_$123"), true);
+    assert_eq!(is_valid_javascript_identifier_original(" foo"), false);
+    assert_eq!(is_valid_javascript_identifier(" foo"), false);
+    assert_eq!(is_valid_javascript_identifier_original("foo "), false);
+    assert_eq!(is_valid_javascript_identifier("foo "), false);
+    assert_eq!(is_valid_javascript_identifier_original("[123]"), false);
+    assert_eq!(is_valid_javascript_identifier("[123]"), false);
+    assert_eq!(is_valid_javascript_identifier_original("foo.bar"), false);
+    assert_eq!(is_valid_javascript_identifier("foo.bar"), false);
+    // Should these pass?
+    assert_eq!(is_valid_javascript_identifier_original("foo [bar]"), true);
+    // assert_eq!(is_valid_javascript_identifier("foo [bar]"), true);
+    assert_eq!(is_valid_javascript_identifier_original("foo[bar]"), true);
+    // assert_eq!(is_valid_javascript_identifier("foo[bar]"), true);
+
+    assert_eq!(get_javascript_token_original("foo "), Some("foo"));
+    assert_eq!(get_javascript_token("foo "), Some("foo"));
+    assert_eq!(get_javascript_token_original("f _hi"), Some("f"));
+    assert_eq!(get_javascript_token("f _hi"), Some("f"));
+    assert_eq!(get_javascript_token_original("foo.bar"), Some("foo"));
+    assert_eq!(get_javascript_token("foo.bar"), Some("foo"));
+    assert_eq!(get_javascript_token_original("[foo,bar]"), None);
+    assert_eq!(get_javascript_token("[foo,bar]"), None);
+}

--- a/src/js_identifiers.rs
+++ b/src/js_identifiers.rs
@@ -11,9 +11,12 @@ fn is_valid_start(c: char) -> bool {
     }
 }
 
-/// Returns true if `c` is a valid character for an identifier part after
-/// start.
+/// Returns true if `c` is a valid character for an identifier part after start.
 fn is_valid_continue(c: char) -> bool {
+    // As specified by the ECMA-262 spec, U+200C (ZERO WIDTH NON-JOINER) and U+200D
+    // (ZERO WIDTH JOINER) are format-control characters that are used to make necessary
+    // distinctions when forming words or phrases in certain languages. They are however
+    // not considered by UnicodeID to be universally valid identifier characters.
     c == '$' || c == '_' || c == '\u{200c}' || c == '\u{200d}' || c.is_ascii_alphanumeric() || {
         if c.is_ascii() {
             false
@@ -45,7 +48,7 @@ fn strip_identifier(s: &str) -> Option<&str> {
             break;
         }
     }
-    return Some(&s[..=end_idx]);
+    Some(&s[..=end_idx])
 }
 
 pub fn is_valid_javascript_identifier(s: &str) -> bool {
@@ -53,6 +56,8 @@ pub fn is_valid_javascript_identifier(s: &str) -> bool {
     strip_identifier(s).map_or(0, |t| t.len()) == s.len()
 }
 
+/// Finds the first valid identifier in the JS Source string given, provided
+/// the string begins with the identifier or whitespace.
 pub fn get_javascript_token(source_line: &str) -> Option<&str> {
     match source_line.split_whitespace().next() {
         Some(s) => strip_identifier(s),
@@ -62,15 +67,15 @@ pub fn get_javascript_token(source_line: &str) -> Option<&str> {
 
 #[test]
 fn test_is_valid_javascript_identifier() {
-    // assert_eq!(is_valid_javascript_identifier("foo 123"), true);
-    assert_eq!(is_valid_javascript_identifier("foo_$123"), true);
-    assert_eq!(is_valid_javascript_identifier(" foo"), false);
-    assert_eq!(is_valid_javascript_identifier("foo "), false);
-    assert_eq!(is_valid_javascript_identifier("[123]"), false);
-    assert_eq!(is_valid_javascript_identifier("foo.bar"), false);
+    // assert_eq!(is_valid_javascript_identifier("foo 123"));
+    assert!(is_valid_javascript_identifier("foo_$123"));
+    assert!(!is_valid_javascript_identifier(" foo"));
+    assert!(!is_valid_javascript_identifier("foo "));
+    assert!(!is_valid_javascript_identifier("[123]"));
+    assert!(!is_valid_javascript_identifier("foo.bar"));
     // Should these pass?
-    // assert_eq!(is_valid_javascript_identifier("foo [bar]"), true);
-    // assert_eq!(is_valid_javascript_identifier("foo[bar]"), true);
+    // assert!(is_valid_javascript_identifier("foo [bar]"));
+    // assert!(is_valid_javascript_identifier("foo[bar]"));
 
     assert_eq!(get_javascript_token("foo "), Some("foo"));
     assert_eq!(get_javascript_token("f _hi"), Some("f"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod detector;
 mod encoder;
 mod errors;
 mod hermes;
+mod js_identifiers;
 mod jsontypes;
 mod sourceview;
 mod types;

--- a/src/ram_bundle.rs
+++ b/src/ram_bundle.rs
@@ -144,7 +144,8 @@ impl<'a> RamBundle<'a> {
     ///
     /// The provided path should point to a javascript file, that serves
     /// as an entry point (startup code) for the app. The modules are stored in js-modules/
-    /// directory, next to the entry point.
+    /// directory, next to the entry point. The js-modules/ directory must ONLY contain
+    /// files with integer names and the ".js" file suffix, along with the UNBUNDLE magic file.
     pub fn parse_unbundle_from_path(bundle_path: &Path) -> Result<Self> {
         Ok(RamBundle {
             repr: RamBundleImpl::Unbundle(UnbundleRamBundle::parse(bundle_path)?),

--- a/src/ram_bundle.rs
+++ b/src/ram_bundle.rs
@@ -195,11 +195,11 @@ impl<'a> RamBundle<'a> {
 /// Filename must be made of ascii-only digits and the .js extension
 /// Anything else errors with `Error::InvalidRamBundleIndex`
 fn js_filename_to_index_strict(filename: &str) -> Result<usize> {
-    match filename.rsplit_once(".js") {
-        Some((basename, "")) => basename
+    match filename.strip_suffix(".js") {
+        Some(basename) => basename
             .parse::<usize>()
             .or(Err(Error::InvalidRamBundleIndex)),
-        _ => Err(Error::InvalidRamBundleIndex),
+        None => Err(Error::InvalidRamBundleIndex),
     }
 }
 /// Represents a file RAM bundle

--- a/src/sourceview.rs
+++ b/src/sourceview.rs
@@ -8,8 +8,8 @@ use if_chain::if_chain;
 
 use crate::detector::{locate_sourcemap_reference_slice, SourceMapRef};
 use crate::errors::Result;
+use crate::js_identifiers::{get_javascript_token, is_valid_javascript_identifier};
 use crate::types::{idx_from_token, sourcemap_from_token, Token};
-use crate::utils::{get_javascript_token, is_valid_javascript_identifier};
 
 /// An iterator that iterates over tokens in reverse.
 pub struct RevTokenIter<'view, 'viewbase, 'map>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,36 +1,6 @@
 use std::borrow::Cow;
 use std::iter::repeat;
 
-use lazy_static::lazy_static;
-use regex::Regex;
-
-lazy_static! {
-    static ref ANCHORED_IDENT_RE: Regex = Regex::new(
-        r#"(?x)
-            ^
-            \s*
-            ([\d\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}$_]
-            [\d\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}$_]*)
-        "#
-    )
-    .unwrap();
-}
-
-pub fn is_valid_javascript_identifier(s: &str) -> bool {
-    // check explicitly we do not have a dot in this identifier so that
-    // we do not match on foo.bar
-    s.trim() == s && !s.contains('.') && ANCHORED_IDENT_RE.is_match(s)
-}
-
-pub fn get_javascript_token(source_line: &str) -> Option<&str> {
-    if let Some(m) = ANCHORED_IDENT_RE.captures(source_line) {
-        let rng = m.get(1).unwrap();
-        Some(&source_line[rng.start()..rng.end()])
-    } else {
-        None
-    }
-}
-
 fn split_path(path: &str) -> Vec<&str> {
     let mut last_idx = 0;
     let mut rv = vec![];


### PR DESCRIPTION
My motivations here are to learn about, and ideally improve the performance of, rust-based frontend tooling.

### Behaviour Changes

The regex crate is used in two separate parts of this lib, **in both cases I have ended up making behavioural changes** - *which I can undo to be more compatible if desired*.

* `filename: &str` -> `index: usize` parsing  in code managing compressed source bundles
  * No longer are any files in the bundle directory ignored, they must all be understood and used by the bundler.
  * I explored a few different options here: https://github.com/willstott101/rust-sourcemap/commit/c6d1debe0df4096c0882859e5b6fa6c9daac693d
* Finding and introspecting JavaScript identifiers
  * `is_valid_javascript_identifier` no longer returns true for invalid identifiers with valid prefixes (see commented test cases)

### unicode-id

I went ahead and used unicode-id as I stole the `is_valid_start` and `is_valid_continue` functions from [swc@5a23949f swc_ecma_ast/src/ident.rs#L180](https://github.com/swc-project/swc/blob/5a23949f1284f71447b9292a374a0cf88759a318/crates/swc_ecma_ast/src/ident.rs#L180) and unicode-id is what swc uses.

### Measurements

|  | Before | After | Notes |
| ------------- | ------------- | - | - |
| Test run (cargo test stdout report) | ~1.0s  | ~0.7s | Bare in mind that I _added_ more tests |
| Compilation from scratch  | ~14.5s  | ~11.5s  | `cargo build --release --examples --offline` |
| `read` example size  | 4770336 | 4761136  | - 9200 bytes   |
| `rewrite` example size  | 4878184  | 4864792  | - 13392 bytes |