### PR TITLE
feat: Switch base64 create for data-encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ all-features = true
 url = "2.1.1"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"
-base64 = "0.13.0"
 unicode-id  = "0.3"
 if_chain = "1.0.0"
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
+data-encoding = "2.3.3"
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -300,7 +300,9 @@ pub fn decode_data_url(url: &str) -> Result<DecodedMap> {
         fail!(Error::InvalidDataUrl);
     }
     let data_b64 = &url[DATA_PREAMBLE.len()..];
-    let data = base64::decode(data_b64).map_err(|_| Error::InvalidDataUrl)?;
+    let data = data_encoding::BASE64
+        .decode(data_b64.as_bytes())
+        .map_err(|_| Error::InvalidDataUrl)?;
     decode_slice(&data[..])
 }
 


### PR DESCRIPTION
This switches out the `base64` create for `data-encoding` which is nicer to use.

Refs https://github.com/marshallpierce/rust-base64/issues/213 and https://github.com/marshallpierce/rust-base64/issues/205