### PR TITLE
fix: Correctly handle protocol-only sourceRoot values

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -189,7 +189,12 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 
     let sources = match rsm.source_root {
         Some(ref source_root) if !source_root.is_empty() => {
-            let source_root = source_root.trim_end_matches('/');
+            let source_root = if source_root.ends_with('/') {
+                source_root[..source_root.len() - 1].to_string()
+            } else {
+                source_root.clone()
+            };
+
             sources
                 .into_iter()
                 .map(|x| {

--- a/tests/test_decoder.rs
+++ b/tests/test_decoder.rs
@@ -73,6 +73,32 @@ fn test_basic_sourcemap_with_root() {
 }
 
 #[test]
+fn test_basic_sourcemap_with_absolute_uri_root() {
+    let input: &[_] = b"{
+        \"version\":3,
+        \"sources\":[\"coolstuff.js\", \"./evencoolerstuff.js\"],
+        \"sourceRoot\":\"webpack:///\",
+        \"names\":[\"x\",\"alert\"],
+        \"mappings\":\"AAAA,GAAIA,GAAI,EACR,ICAIA,GAAK,EAAG,CACVC,MAAM\"
+    }";
+    let sm = SourceMap::from_reader(input).unwrap();
+    let mut iter = sm.tokens().filter(Token::has_name);
+    assert_eq!(
+        iter.next().unwrap().to_tuple(),
+        ("webpack:///coolstuff.js", 0, 4, Some("x"))
+    );
+    assert_eq!(
+        iter.next().unwrap().to_tuple(),
+        ("webpack:///./evencoolerstuff.js", 1, 4, Some("x"))
+    );
+    assert_eq!(
+        iter.next().unwrap().to_tuple(),
+        ("webpack:///./evencoolerstuff.js", 2, 2, Some("alert"))
+    );
+    assert!(iter.next().is_none());
+}
+
+#[test]
 fn test_sourcemap_data_url() {
     let url = "data:application/json;base64,\
                eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvb2xzdHVmZi5qcyJdLCJzb3VyY2VSb290I\


### PR DESCRIPTION
This makes some configurations of Webpack, which emit `"sourceRoot": "webpack:///"` work as expected, and allowing CLI to rewrite sources into `webpack:///./src/foo/bar.js` rather than `webpack:/./src/foo/bar.js`.