### PR TITLE
feat: Support debug ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes & improvements
+
+- feat: Sourcemaps now support debug ids (#66) by @loewenheim
+
 ## 6.2.3
 
 ### Various fixes & improvements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ unicode-id  = "0.3"
 if_chain = "1.0.0"
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
 data-encoding = "2.3.3"
+debugid = {version = "0.8.0", features = ["serde"] }
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use debugid::DebugId;
 use url::Url;
 
 use crate::errors::Result;
@@ -27,6 +28,7 @@ pub struct SourceMapBuilder {
     sources: Vec<String>,
     source_contents: Vec<Option<String>>,
     sources_mapping: Vec<u32>,
+    debug_id: Option<DebugId>,
 }
 
 #[cfg(any(unix, windows, target_os = "redox"))]
@@ -59,7 +61,13 @@ impl SourceMapBuilder {
             sources: vec![],
             source_contents: vec![],
             sources_mapping: vec![],
+            debug_id: None,
         }
+    }
+
+    /// Sets the debug id for the sourcemap (optional)
+    pub fn set_debug_id(&mut self, debug_id: Option<DebugId>) {
+        self.debug_id = debug_id;
     }
 
     /// Sets the file for the sourcemap (optional)
@@ -283,7 +291,14 @@ impl SourceMapBuilder {
             None
         };
 
-        let mut sm = SourceMap::new(self.file, self.tokens, self.names, self.sources, contents);
+        let mut sm = SourceMap::new(
+            self.file,
+            self.tokens,
+            self.names,
+            self.sources,
+            contents,
+            self.debug_id,
+        );
         sm.set_source_root(self.source_root);
 
         sm

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -291,15 +291,9 @@ impl SourceMapBuilder {
             None
         };
 
-        let mut sm = SourceMap::new(
-            self.file,
-            self.tokens,
-            self.names,
-            self.sources,
-            contents,
-            self.debug_id,
-        );
+        let mut sm = SourceMap::new(self.file, self.tokens, self.names, self.sources, contents);
         sm.set_source_root(self.source_root);
+        sm.set_debug_id(self.debug_id);
 
         sm
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -232,15 +232,9 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         _ => "<invalid>".into(),
     });
 
-    let mut sm = SourceMap::new(
-        file,
-        tokens,
-        names,
-        sources,
-        rsm.sources_content,
-        rsm.debug_id,
-    );
+    let mut sm = SourceMap::new(file, tokens, names, sources, rsm.sources_content);
     sm.set_source_root(rsm.source_root);
+    sm.set_debug_id(rsm.debug_id);
 
     Ok(sm)
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -232,7 +232,14 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         _ => "<invalid>".into(),
     });
 
-    let mut sm = SourceMap::new(file, tokens, names, sources, rsm.sources_content);
+    let mut sm = SourceMap::new(
+        file,
+        tokens,
+        names,
+        sources,
+        rsm.sources_content,
+        rsm.debug_id,
+    );
     sm.set_source_root(rsm.source_root);
 
     Ok(sm)

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -93,6 +93,7 @@ impl Encodable for SourceMap {
             x_facebook_offsets: None,
             x_metro_module_paths: None,
             x_facebook_sources: None,
+            debug_id: self.get_debug_id(),
         }
     }
 }
@@ -124,6 +125,7 @@ impl Encodable for SourceMapIndex {
             x_facebook_offsets: None,
             x_metro_module_paths: None,
             x_facebook_sources: None,
+            debug_id: None,
         }
     }
 }

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -1,3 +1,4 @@
+use debugid::DebugId;
 use serde::de::IgnoredAny;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -49,6 +50,8 @@ pub struct RawSourceMap {
     pub x_metro_module_paths: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_facebook_sources: FacebookSources,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debug_id: Option<DebugId>,
 }
 
 #[derive(Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -553,7 +553,6 @@ impl SourceMap {
         names: Vec<String>,
         sources: Vec<String>,
         sources_content: Option<Vec<Option<String>>>,
-        debug_id: Option<DebugId>,
     ) -> SourceMap {
         let mut index: Vec<_> = tokens
             .iter()
@@ -573,7 +572,7 @@ impl SourceMap {
                 .into_iter()
                 .map(|opt| opt.map(SourceView::from_string))
                 .collect(),
-            debug_id,
+            debug_id: None,
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,7 @@ use debugid::DebugId;
 /// * `with_names`: true
 /// * `with_source_contents`: true
 /// * `load_local_source_contents`: false
+#[derive(Debug, Clone)]
 pub struct RewriteOptions<'a> {
     /// If enabled, names are kept in the rewritten sourcemap.
     pub with_names: bool,

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,8 @@ use crate::hermes::SourceMapHermes;
 use crate::sourceview::SourceView;
 use crate::utils::{find_common_prefix, greatest_lower_bound};
 
+use debugid::DebugId;
+
 /// Controls the `SourceMap::rewrite` behavior
 ///
 /// Default configuration:
@@ -461,6 +463,7 @@ pub struct SourceMap {
     source_root: Option<String>,
     sources: Vec<String>,
     sources_content: Vec<Option<SourceView<'static>>>,
+    debug_id: Option<DebugId>,
 }
 
 impl SourceMap {
@@ -550,6 +553,7 @@ impl SourceMap {
         names: Vec<String>,
         sources: Vec<String>,
         sources_content: Option<Vec<Option<String>>>,
+        debug_id: Option<DebugId>,
     ) -> SourceMap {
         let mut index: Vec<_> = tokens
             .iter()
@@ -569,7 +573,18 @@ impl SourceMap {
                 .into_iter()
                 .map(|opt| opt.map(SourceView::from_string))
                 .collect(),
+            debug_id,
         }
+    }
+
+    /// Returns the embedded debug id.
+    pub fn get_debug_id(&self) -> Option<DebugId> {
+        self.debug_id
+    }
+
+    /// Sets a new value for the debug id.
+    pub fn set_debug_id(&mut self, debug_id: Option<DebugId>) {
+        self.debug_id = debug_id
     }
 
     /// Returns the embedded filename in case there is one.
@@ -766,6 +781,7 @@ impl SourceMap {
         options: &RewriteOptions<'_>,
     ) -> Result<(SourceMap, Vec<u32>)> {
         let mut builder = SourceMapBuilder::new(self.get_file());
+        builder.set_debug_id(self.debug_id);
 
         for token in self.tokens() {
             let raw = builder.add_token(&token, options.with_names);
@@ -1063,5 +1079,35 @@ impl SourceMapSection {
     /// Replaces the embedded sourcemap
     pub fn set_sourcemap(&mut self, sm: Option<DecodedMap>) {
         self.map = sm.map(Box::new);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RewriteOptions, SourceMap};
+    use debugid::DebugId;
+
+    #[test]
+    fn test_rewrite_debugid() {
+        let input: &[_] = br#"{
+         "version":3,
+         "sources":["coolstuff.js"],
+         "names":["x","alert"],
+         "mappings":"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
+         "debug_id":"00000000-0000-0000-0000-000000000000"
+     }"#;
+
+        let sm = SourceMap::from_slice(input).unwrap();
+
+        assert_eq!(sm.debug_id, Some(DebugId::default()));
+
+        let new_sm = sm
+            .rewrite(&RewriteOptions {
+                with_names: false,
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert_eq!(new_sm.debug_id, Some(DebugId::default()));
     }
 }


### PR DESCRIPTION
This adds support for reading and writing debug ids in sourcemaps.

Question: Do we also want `SourceMapIndex` to be able to have a debug id?