### PR TITLE
fix: Do not set source_contents if it already exists

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -951,11 +951,12 @@ impl SourceMap {
                 let name = original.get_name(token.name_id);
                 let source = original.get_source(token.src_id);
 
-                if let Some(source) = source {
-                    let contents = original.get_source_contents(token.src_id);
-
-                    let new_id = builder.add_source(source);
-                    builder.set_source_contents(new_id, contents);
+                if !builder.has_source_contents(token.src_id) {
+                    if let Some(source) = source {
+                        let contents = original.get_source_contents(token.src_id);
+                        let new_id = builder.add_source(source);
+                        builder.set_source_contents(new_id, contents);
+                    }
                 }
 
                 let dst_line = (token.dst_line as i32 + line_diff) as u32;


### PR DESCRIPTION
Right now it copies and overrides source over and over again 🥲

A part of bugfix for https://github.com/getsentry/sentry-cli/issues/1710 once it's updated in the cli.