### PR TITLE
feat: Conversion from magic_string::DecodedSourceMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes and improvements
+
+- feat: Conversion from magic_string's DecodedSourceMap type (gated behind magic_string feature)
+
 ## 6.4.1
 
 ### Various fixes & improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Various fixes and improvements
 
-- feat: Conversion from magic_string's DecodedSourceMap type (gated behind magic_string feature)
+- feat: Conversion from magic_string's DecodedSourceMap type (gated behind magic_string feature) (#69) by @loewenheim
 
 ## 6.4.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,14 @@ if_chain = "1.0.0"
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
 data-encoding = "2.3.3"
 debugid = {version = "0.8.0", features = ["serde"] }
+magic_string = {version = "0.3.4", optional = true }
 
 [build-dependencies]
 rustc_version = "0.2.3"
 
 [features]
 ram_bundle = ["scroll"]
+magic_string = ["dep:magic_string"]
 
 [[example]]
 name = "split_ram_bundle"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Functionality of the crate can be turned on and off by feature flags.  This is t
 current list of feature flags:
 
 * `ram_bundle`: turns on RAM bundle support
+* `magic_string`: enables conversion from `magic_string`'s `DecodedSourceMap` type to this crate's `SourceMap` type
 
 
 License: BSD-3-Clause


### PR DESCRIPTION
This adds a conversion function from `magic_string::DecodedSourceMap` to `SourceMap` that avoids serializing the sourcemap to JSON and then parsing it again. The function is gated behind the new `magic_string` feature.