### PR TITLE
fix: Correctly flatten index sourcemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes and improvements
+
+- fix: Fixed a bug in index sourcemap flattening (#74) by @loewenheim
+
 ## 7.0.0
 
 ### Various fixes and improvements

--- a/src/types.rs
+++ b/src/types.rs
@@ -1133,9 +1133,14 @@ impl SourceMapIndex {
             };
 
             for token in map.tokens() {
+                let dst_col = if token.get_dst_line() == 0 {
+                    token.get_dst_col() + off_col
+                } else {
+                    token.get_dst_col()
+                };
                 let raw = builder.add(
                     token.get_dst_line() + off_line,
-                    token.get_dst_col() + off_col,
+                    dst_col,
                     token.get_src_line(),
                     token.get_src_col(),
                     token.get_source(),


### PR DESCRIPTION
The fix turns out to be quite simple: When we look up a position in and index sourcemap, the section's column offset is only applied to its first line. Therefore we need to do the same thing when flattening.