### PR TITLE
fix: Correct sourceRoot logic

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -187,33 +187,7 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         }
     }
 
-    let sources = match rsm.source_root {
-        Some(ref source_root) if !source_root.is_empty() => {
-            let source_root = if let Some(stripped) = source_root.strip_suffix('/') {
-                stripped
-            } else {
-                source_root
-            };
-
-            sources
-                .into_iter()
-                .map(|x| {
-                    let x = x.unwrap_or_default();
-                    let is_valid = !x.is_empty()
-                        && (x.starts_with('/')
-                            || x.starts_with("http:")
-                            || x.starts_with("https:"));
-
-                    if is_valid {
-                        x
-                    } else {
-                        format!("{source_root}/{x}")
-                    }
-                })
-                .collect()
-        }
-        _ => sources.into_iter().map(Option::unwrap_or_default).collect(),
-    };
+    let sources = sources.into_iter().map(Option::unwrap_or_default).collect();
 
     // apparently we can encounter some non string types in real world
     // sourcemaps :(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -84,7 +84,7 @@ impl Encodable for SourceMap {
         RawSourceMap {
             version: Some(3),
             file: self.get_file().map(|x| Value::String(x.to_string())),
-            sources: Some(self.sources().map(|x| Some(x.to_string())).collect()),
+            sources: Some(self.sources.iter().map(|x| Some(x.to_string())).collect()),
             source_root: self.get_source_root().map(|x| x.to_string()),
             sources_content: if have_contents { Some(contents) } else { None },
             sections: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1313,6 +1313,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_roundtrip() {
+        let sm = br#"{
+            "version": 3,
+            "file": "foo.js",
+            "sources": [
+                "./bar.js",
+                "./baz.js"
+            ],
+            "sourceRoot": "webpack:///",
+            "sourcesContent": [null, null],
+            "names": [],
+            "mappings": ""
+        }"#;
+
+        let sm = SourceMap::from_slice(sm).unwrap();
+        let mut out = Vec::new();
+        sm.to_writer(&mut out).unwrap();
+
+        let sm_new = SourceMap::from_slice(&out).unwrap();
+        assert_eq!(sm_new.sources, sm.sources);
+    }
+
     mod prop {
         //! This module exists to test the following property:
         //!

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -9,7 +9,7 @@ fn test_builder_into_sourcemap() {
 
     let sm = builder.into_sourcemap();
     assert_eq!(sm.get_source_root(), Some("/foo/bar"));
-    assert_eq!(sm.get_source(0), Some("baz.js"));
+    assert_eq!(sm.get_source(0), Some("/foo/bar/baz.js"));
     assert_eq!(sm.get_name(0), Some("x"));
 
     let expected = br#"{"version":3,"sources":["baz.js"],"sourceRoot":"/foo/bar","names":["x"],"mappings":""}"#;

--- a/tests/test_decoder.rs
+++ b/tests/test_decoder.rs
@@ -99,6 +99,22 @@ fn test_basic_sourcemap_with_absolute_uri_root() {
 }
 
 #[test]
+fn test_basic_sourcemap_source_root_logic() {
+    let input: &[_] = br#"{
+        "version": 3,
+        "sources": ["coolstuff.js", "/evencoolerstuff.js", "https://awesome.js"],
+        "sourceRoot": "webpack:///",
+        "mappings": ""
+    }"#;
+    let sm = SourceMap::from_reader(input).unwrap();
+    let mut iter = sm.sources();
+    assert_eq!(iter.next().unwrap(), "webpack:///coolstuff.js");
+    assert_eq!(iter.next().unwrap(), "/evencoolerstuff.js");
+    assert_eq!(iter.next().unwrap(), "https://awesome.js");
+    assert!(iter.next().is_none());
+}
+
+#[test]
 fn test_sourcemap_data_url() {
     let url = "data:application/json;base64,\
                eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvb2xzdHVmZi5qcyJdLCJzb3VyY2VSb290I\


### PR DESCRIPTION
This changes sourcemap parsing so that source names are not automatically prefixed with the `sourceRoot` field. The problem with doing that is that reading and then immediately writing a sourcemap would result in the source names changing.

Instead, `SourceMap` now maintains a copy of the vector of source names with the `sourceRoot` prefix prepended. Obviously this copy needs to be kept in sync with the original source names whenever a source name or the `sourceRoot` changes.

Note that this PR changes the behavior of `SourceMapBuilder` somewhat. Now, there is no difference between parsing a sourcemap like 
```json
{ "sourceRoot": "root", "sources": ["foo.js", "bar.js"], [...]}
```
and constructing it with a builder:
```rust
let mut builder = SourceMapBuilder::new(None);
builder.set_source_root(Some("root"));
builder.add_source("foo.js");
builder.add_source("bar.js");
builder.into_sourcemap();
```
Before, the parsed version would've contained the sources `"root/foo.js"` and `"root/bar.js"`, while the constructed version would've had `"foo.js"` and `"bar.js"`