### PR TITLE
feat: Replace `unicode-id` crate with `unicode-id-start`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 url = "2.1.1"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"
-unicode-id  = "0.3"
+unicode-id-start = "1"
 if_chain = "1.0.0"
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
 data-encoding = "2.3.3"

--- a/src/js_identifiers.rs
+++ b/src/js_identifiers.rs
@@ -1,4 +1,4 @@
-use unicode_id::UnicodeID;
+use unicode_id_start;
 
 /// Returns true if `c` is a valid character for an identifier start.
 fn is_valid_start(c: char) -> bool {
@@ -6,7 +6,7 @@ fn is_valid_start(c: char) -> bool {
         if c.is_ascii() {
             false
         } else {
-            UnicodeID::is_id_start(c)
+            unicode_id_start::is_id_start_unicode(c)
         }
     }
 }
@@ -21,7 +21,7 @@ fn is_valid_continue(c: char) -> bool {
         if c.is_ascii() {
             false
         } else {
-            UnicodeID::is_id_continue(c)
+            unicode_id_start::is_id_continue_unicode(c)
         }
     }
 }

--- a/src/js_identifiers.rs
+++ b/src/js_identifiers.rs
@@ -1,5 +1,3 @@
-use unicode_id_start;
-
 /// Returns true if `c` is a valid character for an identifier start.
 fn is_valid_start(c: char) -> bool {
     c == '$' || c == '_' || c.is_ascii_alphabetic() || {


### PR DESCRIPTION
We've gone full circle :sweat_smile:

The `unicode-id` and `unicode-id-start` crates were cloned from [`unicode-xid`](https://crates.io/crates/unicode-xid) and [`unicode-ident`](https://crates.io/crates/unicode-ident) for usages in the [oxc project](https://github.com/oxc-project/oxc).

Oxc will be using this crate for sourcemap support, and is currently using the better optimized `unicode-id-start` crate. I don't want to include two similar dependencies due to the rather large static storage size of these crates.

The `unicode-id-start` crate is also faster and uses slightly less static storage. See full details at https://github.com/oxc-project/unicode-id-start/tree/master?tab=readme-ov-file#comparison-of-performance

---

The version "1" is used instead of the latest version because the crate is stable, future versions will only include unicode version upgrades.

---

And thank you Sentry for the sponsorship due to the inclusion of `unicode-id` crate ❤️ 