### PR TITLE
perf: using Arc<str> instead of String

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,12 +20,12 @@ use crate::types::{RawToken, SourceMap, Token};
 /// objects is generally not very comfortable.  As a general aid this
 /// type can help.
 pub struct SourceMapBuilder {
-    file: Option<String>,
+    file: Option<Arc<str>>,
     name_map: FxHashMap<Arc<str>, u32>,
     names: Vec<Arc<str>>,
     tokens: Vec<RawToken>,
     source_map: FxHashMap<Arc<str>, u32>,
-    source_root: Option<String>,
+    source_root: Option<Arc<str>>,
     sources: Vec<Arc<str>>,
     source_contents: Vec<Option<Arc<str>>>,
     sources_mapping: Vec<u32>,
@@ -54,7 +54,7 @@ impl SourceMapBuilder {
     pub fn new(file: Option<&str>) -> SourceMapBuilder {
         SourceMapBuilder {
             file: file.map(str::to_owned),
-            name_map: FxHashMap::default(),
+            name_map: HashMap::new(),
             names: vec![],
             tokens: vec![],
             source_map: FxHashMap::default(),
@@ -72,7 +72,7 @@ impl SourceMapBuilder {
     }
 
     /// Sets the file for the sourcemap (optional)
-    pub fn set_file<T: Into<String>>(&mut self, value: Option<T>) {
+    pub fn set_file<T: Into<Arc<str>>>(&mut self, value: Option<T>) {
         self.file = value.map(Into::into);
     }
 
@@ -82,7 +82,7 @@ impl SourceMapBuilder {
     }
 
     /// Sets a new value for the source_root.
-    pub fn set_source_root<T: Into<String>>(&mut self, value: Option<T>) {
+    pub fn set_source_root<T: Into<Arc<str>>>(&mut self, value: Option<T>) {
         self.source_root = value.map(Into::into);
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -53,8 +53,8 @@ impl SourceMapBuilder {
     /// Creates a new source map builder and sets the file.
     pub fn new(file: Option<&str>) -> SourceMapBuilder {
         SourceMapBuilder {
-            file: file.map(str::to_owned),
-            name_map: HashMap::new(),
+            file: file.map(Into::into),
+            name_map: FxHashMap::default(),
             names: vec![],
             tokens: vec![],
             source_map: FxHashMap::default(),

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -206,7 +206,7 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 
     // file sometimes is not a string for unexplicable reasons
     let file = rsm.file.map(|val| match val {
-        Value::String(s) => s,
+        Value::String(s) => s.into(),
         _ => "<invalid>".into(),
     });
 

--- a/src/ram_bundle.rs
+++ b/src/ram_bundle.rs
@@ -70,9 +70,9 @@ impl<'a> RamBundleModule<'a> {
     /// Returns a source view of the data.
     ///
     /// This operation fails if the source code is not valid UTF-8.
-    pub fn source_view(&self) -> Result<SourceView<'a>> {
+    pub fn source_view(&self) -> Result<SourceView> {
         match std::str::from_utf8(self.data) {
-            Ok(s) => Ok(SourceView::new(s)),
+            Ok(s) => Ok(SourceView::new(s.into())),
             Err(e) => Err(Error::Utf8(e)),
         }
     }
@@ -361,7 +361,7 @@ impl<'a> SplitRamBundleModuleIter<'a> {
     fn split_module(
         &self,
         module: RamBundleModule<'a>,
-    ) -> Result<Option<(String, SourceView<'a>, SourceMap)>> {
+    ) -> Result<Option<(String, SourceView, SourceMap)>> {
         let module_offset = self
             .offsets
             .get(module.id())
@@ -377,7 +377,7 @@ impl<'a> SplitRamBundleModuleIter<'a> {
             return Err(Error::InvalidRamBundleEntry);
         }
 
-        let source: SourceView<'a> = module.source_view()?;
+        let source: SourceView = module.source_view()?;
         let line_count = source.line_count() as u32;
         let ending_line = starting_line + line_count;
         let last_line_len = source
@@ -416,7 +416,7 @@ impl<'a> SplitRamBundleModuleIter<'a> {
 }
 
 impl<'a> Iterator for SplitRamBundleModuleIter<'a> {
-    type Item = Result<(String, SourceView<'a>, SourceMap)>;
+    type Item = Result<(String, SourceView, SourceMap)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(module_result) = self.ram_bundle_iter.next() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -458,11 +458,11 @@ pub struct SourceMapIndex {
 /// rejected with an error on reading.
 #[derive(Clone, Debug)]
 pub struct SourceMap {
-    pub(crate) file: Option<String>,
+    pub(crate) file: Option<Arc<str>>,
     pub(crate) tokens: Vec<RawToken>,
     pub(crate) index: Vec<(u32, u32, u32)>,
     pub(crate) names: Vec<Arc<str>>,
-    pub(crate) source_root: Option<String>,
+    pub(crate) source_root: Option<Arc<str>>,
     pub(crate) sources: Vec<Arc<str>>,
     pub(crate) sources_prefixed: Option<Vec<Arc<str>>>,
     pub(crate) sources_content: Vec<Option<SourceView>>,
@@ -574,7 +574,7 @@ impl SourceMap {
     /// - `sources` a vector of source filenames
     /// - `sources_content` optional source contents
     pub fn new(
-        file: Option<String>,
+        file: Option<Arc<str>>,
         tokens: Vec<RawToken>,
         names: Vec<Arc<str>>,
         sources: Vec<Arc<str>>,
@@ -619,7 +619,7 @@ impl SourceMap {
     }
 
     /// Sets a new value for the file.
-    pub fn set_file<T: Into<String>>(&mut self, value: Option<T>) {
+    pub fn set_file<T: Into<Arc<str>>>(&mut self, value: Option<T>) {
         self.file = value.map(Into::into);
     }
 
@@ -643,7 +643,7 @@ impl SourceMap {
     }
 
     /// Sets a new value for the source_root.
-    pub fn set_source_root<T: Into<String>>(&mut self, value: Option<T>) {
+    pub fn set_source_root<T: Into<Arc<str>>>(&mut self, value: Option<T>) {
         self.source_root = value.map(Into::into);
 
         match self.source_root.as_deref().filter(|rs| !rs.is_empty()) {

--- a/tests/test_namemap.rs
+++ b/tests/test_namemap.rs
@@ -4,7 +4,7 @@ use sourcemap::{SourceMap, SourceView};
 fn test_basic_name_mapping() {
     let input: &[_] = br#"{"version":3,"file":"test.min.js","sources":["test.js"],"names":["makeAFailure","testingStuff","Error","onSuccess","data","onFailure","invoke","cb","failed","test","value"],"mappings":"AAAA,GAAIA,cAAe,WACjB,QAASC,KACP,GAAIA,GAAe,EACnB,MAAM,IAAIC,OAAMD,GAGlB,QAASE,GAAUC,GACjBH,IAGF,QAASI,GAAUD,GACjB,KAAM,IAAIF,OAAM,WAGlB,QAASI,GAAOF,GACd,GAAIG,GAAK,IACT,IAAIH,EAAKI,OAAQ,CACfD,EAAKF,MACA,CACLE,EAAKJ,EAEPI,EAAGH,GAGL,QAASK,KACP,GAAIL,IAAQI,OAAQ,KAAME,MAAO,GACjCJ,GAAOF,GAGT,MAAOK","sourcesContent":["var makeAFailure = (function() {\n  function testingStuff() {\n    var testingStuff = 42;\n    throw new Error(testingStuff);\n  }\n\n  function onSuccess(data) {\n    testingStuff();\n  }\n\n  function onFailure(data) {\n    throw new Error('failed!');\n  }\n\n  function invoke(data) {\n    var cb = null;\n    if (data.failed) {\n      cb = onFailure;\n    } else {\n      cb = onSuccess;\n    }\n    cb(data);\n  }\n\n  function test() {\n    var data = {failed: true, value: 42};\n    invoke(data);\n  }\n\n  return test;\n})();\n"]}"#;
     let minified_file = r#"var makeAFailure=function(){function n(){var n=42;throw new Error(n)}function r(r){n()}function e(n){throw new Error("failed!")}function i(n){var i=null;if(n.failed){i=e}else{i=r}i(n)}function u(){var n={failed:true,value:42};i(n)}return u}();"#;
-    let sv = SourceView::new(minified_file);
+    let sv = SourceView::new(minified_file.into());
     let sm = SourceMap::from_reader(input).unwrap();
 
     let name = sm.get_original_function_name(0, 107, "e", &sv);
@@ -27,7 +27,7 @@ fn test_basic_name_mapping() {
 fn test_unicode_mapping() {
     let input = r#"{"version":3,"file":"test.min.js","sources":["test.js"],"names":["makeAFailure","onSuccess","data","onFailure","Error","invoke","cb","failed","㮏","value"],"mappings":"AAAA,GAAIA,cAAe,WACjB,QAASC,GAAUC,IAEnB,QAASC,GAAUD,IACjB,WACE,KAAM,IAAIE,OAAM,eAIpB,QAASC,GAAOH,GACd,GAAII,GAAK,IACT,IAAIJ,EAAKK,OAAQ,CACfD,EAAKH,MACA,CACLG,EAAKL,EAEPK,EAAGJ,GAGI,QAASM,KAChB,GAAIN,IAAQK,OAAQ,KAAME,MAAO,GACjCJ,GAAOH,GAGT,MAAOM","sourcesContent":["var makeAFailure = (function() {\n  function onSuccess(data) {}\n\n  function onFailure(data) {\n    (function() {\n      throw new Error('failed!');\n    })();\n  }\n\n  function invoke(data) {\n    var cb = null;\n    if (data.failed) {\n      cb = onFailure;\n    } else {\n      cb = onSuccess;\n    }\n    cb(data);\n  }\n\n  /* 😍 */ function 㮏() {\n    var data = {failed: true, value: 42};\n    invoke(data);\n  }\n\n  return 㮏;\n})();\n"]}"#.as_bytes();
     let minified_file = r#"var makeAFailure=function(){function n(n){}function e(n){(function(){throw new Error("failed!")})()}function i(i){var r=null;if(i.failed){r=e}else{r=n}r(i)}function r(){var n={failed:true,value:42};i(n)}return r}();"#;
-    let sv = SourceView::new(minified_file);
+    let sv = SourceView::new(minified_file.into());
     let sm = SourceMap::from_reader(input).unwrap();
 
     // stacktrace


### PR DESCRIPTION
Here has some unnecessary memory alloc, and the pr intends to fix them.

<img width="1622" alt="image" src="https://github.com/getsentry/rust-sourcemap/assets/14008915/f899bc76-b98f-4351-b327-6d20b6f9f47d">

Here has a example.

``` rs
fn add_source_with_id(&mut self, src: &str, old_id: u32) -> u32 {
        let count = self.sources.len() as u32;
        let id = *self.source_map.entry(src.into()).or_insert(count); // Here `src.into` -> `String` only calculate hash, it is unnecessary.
        if id == count {
            self.sources.push(src.into()); // Here `src.into` -> `String` to store,  it is unnecessary.
            self.sources_mapping.push(old_id);
        }
        id
    }
```
