### PR TITLE
feat: Skip encoding range mappings if it's empty

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -60,6 +60,7 @@ fn serialize_range_mappings(sm: &SourceMap) -> Option<String> {
     let mut buf = Vec::new();
     let mut prev_line = 0;
     let mut had_rmi = false;
+    let mut empty = true;
 
     let mut idx_of_first_in_line = 0;
 
@@ -68,6 +69,7 @@ fn serialize_range_mappings(sm: &SourceMap) -> Option<String> {
     for (idx, token) in sm.tokens().enumerate() {
         if token.is_range() {
             had_rmi = true;
+            empty = false;
 
             let num = idx - idx_of_first_in_line;
 
@@ -89,6 +91,10 @@ fn serialize_range_mappings(sm: &SourceMap) -> Option<String> {
             idx_of_first_in_line = idx;
         }
     }
+    if empty {
+        return None;
+    }
+
     if had_rmi {
         encode_rmi(&mut buf, &mut rmi_data);
     }

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -12,7 +12,7 @@ fn test_builder_into_sourcemap() {
     assert_eq!(sm.get_source(0), Some("/foo/bar/baz.js"));
     assert_eq!(sm.get_name(0), Some("x"));
 
-    let expected = br#"{"version":3,"sources":["baz.js"],"sourceRoot":"/foo/bar","names":["x"],"rangeMappings":"","mappings":""}"#;
+    let expected = br#"{"version":3,"sources":["baz.js"],"sourceRoot":"/foo/bar","names":["x"],"mappings":""}"#;
     let mut output: Vec<u8> = vec![];
     sm.to_writer(&mut output).unwrap();
     assert_eq!(output, expected);

--- a/tests/test_encoder.rs
+++ b/tests/test_encoder.rs
@@ -45,3 +45,23 @@ fn test_basic_range() {
         assert_eq!(tok1, tok2);
     }
 }
+
+#[test]
+fn test_empty_range() {
+    let input = r#"{
+        "version": 3,
+        "sources": [null],
+        "names": ["console","log","ab"],
+        "mappings": "AACAA,QAAQC,GAAG,CAAC,OAAM,OAAM,QACxBD,QAAQC,GAAG,CAAC,QAEZD,QAAQC,GAAG,CAJD;IAACC,IAAI;AAAI,IAKnBF,QAAQC,GAAG,CAAC,YACZD,QAAQC,GAAG,CAAC",
+        "rangeMappings": ""
+    }"#;
+    let sm = SourceMap::from_reader(input.as_bytes()).unwrap();
+    let mut out: Vec<u8> = vec![];
+    sm.to_writer(&mut out).unwrap();
+
+    let out = String::from_utf8(out.clone()).unwrap();
+
+    println!("{}", out);
+
+    assert!(out.contains("\"rangeMappings\":[]"));
+}

--- a/tests/test_encoder.rs
+++ b/tests/test_encoder.rs
@@ -23,7 +23,7 @@ fn test_basic_sourcemap() {
 fn test_sourcemap_data_url() {
     let input: &[_] = br#"{"version":3,"file":"build/foo.min.js","sources":["src/foo.js"],"names":[],"mappings":"AAAA","sourceRoot":"/"}"#;
     let sm = SourceMap::from_reader(input).unwrap();
-    assert_eq!(sm.to_data_url().unwrap(), "data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYnVpbGQvZm9vLm1pbi5qcyIsInNvdXJjZXMiOlsic3JjL2Zvby5qcyJdLCJzb3VyY2VSb290IjoiLyIsIm5hbWVzIjpbXSwicmFuZ2VNYXBwaW5ncyI6IiIsIm1hcHBpbmdzIjoiQUFBQSJ9");
+    assert_eq!(sm.to_data_url().unwrap(), "data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYnVpbGQvZm9vLm1pbi5qcyIsInNvdXJjZXMiOlsic3JjL2Zvby5qcyJdLCJzb3VyY2VSb290IjoiLyIsIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBIn0=");
 }
 
 #[test]
@@ -63,5 +63,5 @@ fn test_empty_range() {
 
     println!("{}", out);
 
-    assert!(out.contains("\"rangeMappings\":[]"));
+    assert!(!out.contains("rangeMappings"));
 }

--- a/tests/test_encoder.rs
+++ b/tests/test_encoder.rs
@@ -59,9 +59,6 @@ fn test_empty_range() {
     let mut out: Vec<u8> = vec![];
     sm.to_writer(&mut out).unwrap();
 
-    let out = String::from_utf8(out.clone()).unwrap();
-
-    println!("{}", out);
-
+    let out = String::from_utf8(out).unwrap();
     assert!(!out.contains("rangeMappings"));
 }


### PR DESCRIPTION
The current code generates source map like

```json
{
  "mappings": ";;UAAUA;MACOC,IAAI;IACV,SAASC;QACZC,QAAQC,GAAG,GAACH;IAChB;MAFgBC,IAAAA;AAGpB,GALUF,MAAAA",
  "names": [
    "A",
    "v",
    "a",
    "console",
    "log"
  ],
  "rangeMappings": ";;;;;;;;",
  "sources": [
    "../../input/index.ts"
  ],
  "sourcesContent": [
    "namespace A {\n    export const v = 25;\n    export function a() {\n        console.log(v);\n    }\n}\n"
  ],
  "version": 3
}

```

where `rangeMappings` is useless. This PR modifies the encoder to skip encoding if there's no meaningful data