### PR TITLE
Remove documentation entry from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Sentry <hello@sentry.io>"]
 keywords = ["javascript", "sourcemap", "sourcemaps"]
 description = "Basic sourcemap handling for Rust"
 homepage = "https://github.com/getsentry/rust-sourcemap"
-documentation = "https://getsentry.github.io/rust-sourcemap/"
 repository = "https://github.com/getsentry/rust-sourcemap"
 license = "BSD-3-Clause"
 readme = "README.md"


### PR DESCRIPTION
The document in https://getsentry.github.io/rust-sourcemap/ seems to be too old.

How about removing the `documentation` entry from `Cargo.toml`.
If so, the latest document (https://docs.rs/sourcemap/latest/sourcemap/) will be linked from crates.io.