### PR TITLE
fix: Prevent infinite loop

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -83,7 +83,7 @@ fn serialize_range_mappings(sm: &SourceMap) -> Option<String> {
             rmi_bits.set(num, true);
         }
 
-        while token.get_dst_line() != prev_line {
+        while token.get_dst_line() > prev_line {
             if had_rmi {
                 encode_rmi(&mut buf, &mut rmi_data);
                 rmi_data.clear();
@@ -121,7 +121,7 @@ fn serialize_mappings(sm: &SourceMap) -> String {
 
         if token.get_dst_line() != prev_dst_line {
             prev_dst_col = 0;
-            while token.get_dst_line() != prev_dst_line {
+            while token.get_dst_line() > prev_dst_line {
                 rv.push(';');
                 prev_dst_line += 1;
             }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -57,6 +57,10 @@ fn encode_rmi(out: &mut Vec<u8>, data: &mut Vec<u8>) {
 }
 
 fn serialize_range_mappings(sm: &SourceMap) -> Option<String> {
+    if sm.tokens().all(|t| !t.is_range()) {
+        return None;
+    }
+
     let mut buf = Vec::new();
     let mut prev_line = 0;
     let mut had_rmi = false;


### PR DESCRIPTION
Context: https://github.com/swc-project/swc/pull/9050

- To show the proof for the fix, I made the SWC PR draft and used `kdy1/rust-sourcemap.git#skip-range`

I used `adjust_mapping`, but I found `sourcemap` crate is panicking with integer overflow. The cause was

```rust
            while token.get_dst_line() != prev_dst_line {
                rv.push(';');
                prev_dst_line += 1;
            }
```

so I modified it to

```rust
            while token.get_dst_line() > prev_dst_line {
                rv.push(';');
                prev_dst_line += 1;
            }

```

and it worked.