### PR TITLE
ref: Sort tokens in SourceMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes and improvements
+
+- ref: Tokens within a sourcemap are now always sorted by their position in the
+       minified file. Consequently:
+        - the type `IndexIter` and the functions `get_index_size`, `index_iter`,
+          and `idx_from_token` have been deleted;
+        - the function `sourcemap_from_token` has been turned into the method
+          `sourcemap` on `Token`;
+        - the `idx` parameter of `SourceMap::get_token` now has the type `usize`.
+
 ## 8.0.1
 
 ### Various fixes & improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 ### Various fixes and improvements
 
 - ref: Tokens within a sourcemap are now always sorted by their position in the
-       minified file. Consequently:
-        - the type `IndexIter` and the functions `get_index_size`, `index_iter`,
-          and `idx_from_token` have been deleted;
-        - the function `sourcemap_from_token` has been turned into the method
-          `sourcemap` on `Token`;
-        - the `idx` parameter of `SourceMap::get_token` now has the type `usize`.
+      minified file (#91) by @loewenheim.
+      Consequently:
+      - the type `IndexIter` and the functions `get_index_size`, `index_iter`,
+        and `idx_from_token` have been deleted;
+      - the function `sourcemap_from_token` has been turned into the method
+        `sourcemap` on `Token`;
+      - the `idx` parameter of `SourceMap::get_token` now has the type `usize`.
+
 
 ## 8.0.1
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -113,8 +113,6 @@ fn serialize_mappings(sm: &SourceMap) -> String {
     let mut prev_src_id = 0;
 
     for (idx, token) in sm.tokens().enumerate() {
-        let idx = idx as u32;
-
         if token.get_dst_line() != prev_dst_line {
             prev_dst_col = 0;
             while token.get_dst_line() != prev_dst_line {

--- a/src/hermes.rs
+++ b/src/hermes.rs
@@ -108,9 +108,10 @@ impl SourceMapHermes {
 
         // Find the closest mapping, just like here:
         // https://github.com/facebook/metro/blob/63b523eb20e7bdf62018aeaf195bb5a3a1a67f36/packages/metro-symbolicate/src/SourceMetadataMapConsumer.js#L204-L231
-        let mapping = greatest_lower_bound(&function_map.mappings, &token.get_src(), |o| {
-            (o.line, o.column)
-        })?;
+        let (_mapping_idx, mapping) =
+            greatest_lower_bound(&function_map.mappings, &token.get_src(), |o| {
+                (o.line, o.column)
+            })?;
         function_map
             .names
             .get(mapping.name_index as usize)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@ pub use crate::errors::{Error, Result};
 pub use crate::hermes::SourceMapHermes;
 pub use crate::sourceview::SourceView;
 pub use crate::types::{
-    DecodedMap, IndexIter, NameIter, RawToken, RewriteOptions, SourceContentsIter, SourceIter,
-    SourceMap, SourceMapIndex, SourceMapSection, SourceMapSectionIter, Token, TokenIter,
+    DecodedMap, NameIter, RawToken, RewriteOptions, SourceContentsIter, SourceIter, SourceMap,
+    SourceMapIndex, SourceMapSection, SourceMapSectionIter, Token, TokenIter,
 };
 pub use crate::utils::make_relative_path;
 

--- a/src/sourceview.rs
+++ b/src/sourceview.rs
@@ -11,7 +11,7 @@ use if_chain::if_chain;
 use crate::detector::{locate_sourcemap_reference_slice, SourceMapRef};
 use crate::errors::Result;
 use crate::js_identifiers::{get_javascript_token, is_valid_javascript_identifier};
-use crate::types::{idx_from_token, sourcemap_from_token, Token};
+use crate::types::Token;
 
 /// An iterator that iterates over tokens in reverse.
 pub struct RevTokenIter<'view, 'map> {
@@ -24,17 +24,11 @@ impl<'view, 'map> Iterator for RevTokenIter<'view, 'map> {
     type Item = (Token<'map>, Option<&'view str>);
 
     fn next(&mut self) -> Option<(Token<'map>, Option<&'view str>)> {
-        let token = match self.token.take() {
-            None => {
-                return None;
-            }
-            Some(token) => token,
-        };
+        let token = self.token.take()?;
+        let idx = token.idx;
 
-        let idx = idx_from_token(&token);
         if idx > 0 {
-            let sm = sourcemap_from_token(&token);
-            self.token = sm.get_token(idx - 1);
+            self.token = token.sm.get_token(idx - 1);
         }
 
         // if we are going to the same line as we did last iteration, we don't have to scan

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -118,13 +118,13 @@ pub fn greatest_lower_bound<'a, T, K: Ord, F: Fn(&'a T) -> K>(
     slice: &'a [T],
     key: &K,
     map: F,
-) -> Option<&'a T> {
+) -> Option<(usize, &'a T)> {
     let mut idx = match slice.binary_search_by_key(key, &map) {
         Ok(index) => index,
         Err(index) => {
             // If there is no match, then we know for certain that the index is where we should
             // insert a new token, and that the token directly before is the greatest lower bound.
-            return slice.get(index.checked_sub(1)?);
+            return slice.get(index.checked_sub(1)?).map(|res| (index, res));
         }
     };
 
@@ -138,7 +138,7 @@ pub fn greatest_lower_bound<'a, T, K: Ord, F: Fn(&'a T) -> K>(
             break;
         }
     }
-    slice.get(idx)
+    slice.get(idx).map(|res| (idx, res))
 }
 
 #[test]
@@ -201,27 +201,27 @@ fn test_greatest_lower_bound() {
     let cmp = |&(i, _id)| i;
 
     let haystack = vec![(1, 1)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp), Some(&(1, 1)));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp), Some(&(1, 1)));
+    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 1));
     assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 
     let haystack = vec![(1, 1), (1, 2)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp), Some(&(1, 1)));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp), Some(&(1, 2)));
+    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 2));
     assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 
     let haystack = vec![(1, 1), (1, 2), (1, 3)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp), Some(&(1, 1)));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp), Some(&(1, 3)));
+    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 3));
     assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 
     let haystack = vec![(1, 1), (1, 2), (1, 3), (1, 4)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp), Some(&(1, 1)));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp), Some(&(1, 4)));
+    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 4));
     assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 
     let haystack = vec![(1, 1), (1, 2), (1, 3), (1, 4), (1, 5)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp), Some(&(1, 1)));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp), Some(&(1, 5)));
+    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 5));
     assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 }


### PR DESCRIPTION
The fact that the tokens in a sourcemap can be arbitrarily ordered causes a substantial amount of complication (we have to keep a sorted index in addition) for no benefit that I've ever seen. Therefore, we now sort tokens upon creation and remove all the `Index` rigmarole. This is a breaking change because it removes some types and functions.