### PR TITLE
Add support for ignoreList property

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -308,16 +308,12 @@ impl SourceMapBuilder {
             None
         };
 
-        let mut sm = SourceMap::new(
-            self.file,
-            self.tokens,
-            self.names,
-            self.sources,
-            contents,
-            Some(self.ignore_list.into_iter().collect()),
-        );
+        let mut sm = SourceMap::new(self.file, self.tokens, self.names, self.sources, contents);
         sm.set_source_root(self.source_root);
         sm.set_debug_id(self.debug_id);
+        for ignored_src_id in self.ignore_list {
+            sm.add_to_ignore_list(ignored_src_id);
+        }
 
         sm
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(any(unix, windows, target_os = "redox")), allow(unused_imports))]
 
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::io::Read;
@@ -28,6 +29,7 @@ pub struct SourceMapBuilder {
     sources: Vec<Arc<str>>,
     source_contents: Vec<Option<Arc<str>>>,
     sources_mapping: Vec<u32>,
+    ignore_list: BTreeSet<u32>,
     debug_id: Option<DebugId>,
 }
 
@@ -61,6 +63,7 @@ impl SourceMapBuilder {
             sources: vec![],
             source_contents: vec![],
             sources_mapping: vec![],
+            ignore_list: BTreeSet::default(),
             debug_id: None,
         }
     }
@@ -114,6 +117,10 @@ impl SourceMapBuilder {
     /// Looks up a source name for an ID.
     pub fn get_source(&self, src_id: u32) -> Option<&str> {
         self.sources.get(src_id as usize).map(|x| &x[..])
+    }
+
+    pub fn add_to_ignore_list(&mut self, src_id: u32) {
+        self.ignore_list.insert(src_id);
     }
 
     /// Sets the source contents for an already existing source.
@@ -301,7 +308,14 @@ impl SourceMapBuilder {
             None
         };
 
-        let mut sm = SourceMap::new(self.file, self.tokens, self.names, self.sources, contents);
+        let mut sm = SourceMap::new(
+            self.file,
+            self.tokens,
+            self.names,
+            self.sources,
+            contents,
+            Some(self.ignore_list.iter().cloned().collect()),
+        );
         sm.set_source_root(self.source_root);
         sm.set_debug_id(self.debug_id);
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -314,7 +314,7 @@ impl SourceMapBuilder {
             self.names,
             self.sources,
             contents,
-            Some(self.ignore_list.iter().cloned().collect()),
+            Some(self.ignore_list.into_iter().collect()),
         );
         sm.set_source_root(self.source_root);
         sm.set_debug_id(self.debug_id);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -251,7 +251,14 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         .sources_content
         .map(|x| x.into_iter().map(|v| v.map(Into::into)).collect::<Vec<_>>());
 
-    let mut sm = SourceMap::new(file, tokens, names, sources, source_content);
+    let mut sm = SourceMap::new(
+        file,
+        tokens,
+        names,
+        sources,
+        source_content,
+        rsm.ignore_list,
+    );
     sm.set_source_root(rsm.source_root);
     sm.set_debug_id(rsm.debug_id);
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -251,16 +251,14 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         .sources_content
         .map(|x| x.into_iter().map(|v| v.map(Into::into)).collect::<Vec<_>>());
 
-    let mut sm = SourceMap::new(
-        file,
-        tokens,
-        names,
-        sources,
-        source_content,
-        rsm.ignore_list,
-    );
+    let mut sm = SourceMap::new(file, tokens, names, sources, source_content);
     sm.set_source_root(rsm.source_root);
     sm.set_debug_id(rsm.debug_id);
+    if let Some(ignore_list) = rsm.ignore_list {
+        for idx in ignore_list {
+            sm.add_to_ignore_list(idx);
+        }
+    }
 
     Ok(sm)
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -170,6 +170,11 @@ impl Encodable for SourceMap {
             names: Some(self.names().map(|x| Value::String(x.to_string())).collect()),
             range_mappings: serialize_range_mappings(self),
             mappings: Some(serialize_mappings(self)),
+            ignore_list: if self.ignore_list.is_empty() {
+                None
+            } else {
+                Some(self.ignore_list.iter().cloned().collect())
+            },
             x_facebook_offsets: None,
             x_metro_module_paths: None,
             x_facebook_sources: None,
@@ -203,6 +208,7 @@ impl Encodable for SourceMapIndex {
             names: None,
             range_mappings: None,
             mappings: None,
+            ignore_list: None,
             x_facebook_offsets: None,
             x_metro_module_paths: None,
             x_facebook_sources: None,

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -46,6 +46,8 @@ pub struct RawSourceMap {
     pub range_mappings: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mappings: Option<String>,
+    #[serde(rename = "ignoreList", skip_serializing_if = "Option::is_none")]
+    pub ignore_list: Option<Vec<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_facebook_offsets: Option<Vec<Option<u32>>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -580,7 +580,6 @@ impl SourceMap {
         names: Vec<Arc<str>>,
         sources: Vec<Arc<str>>,
         sources_content: Option<Vec<Option<Arc<str>>>>,
-        ignore_list: Option<Vec<u32>>,
     ) -> SourceMap {
         tokens.sort_unstable_by_key(|t| (t.dst_line, t.dst_col));
         SourceMap {
@@ -595,10 +594,7 @@ impl SourceMap {
                 .into_iter()
                 .map(|opt| opt.map(SourceView::new))
                 .collect(),
-            ignore_list: match ignore_list {
-                Some(ignore_list) => ignore_list.into_iter().collect(),
-                None => BTreeSet::default(),
-            },
+            ignore_list: BTreeSet::default(),
             debug_id: None,
         }
     }

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -6,13 +6,14 @@ fn test_builder_into_sourcemap() {
     builder.set_source_root(Some("/foo/bar"));
     builder.add_source("baz.js");
     builder.add_name("x");
+    builder.add_to_ignore_list(0);
 
     let sm = builder.into_sourcemap();
     assert_eq!(sm.get_source_root(), Some("/foo/bar"));
     assert_eq!(sm.get_source(0), Some("/foo/bar/baz.js"));
     assert_eq!(sm.get_name(0), Some("x"));
 
-    let expected = br#"{"version":3,"sources":["baz.js"],"sourceRoot":"/foo/bar","names":["x"],"mappings":""}"#;
+    let expected = br#"{"version":3,"sources":["baz.js"],"sourceRoot":"/foo/bar","names":["x"],"mappings":"","ignoreList":[0]}"#;
     let mut output: Vec<u8> = vec![];
     sm.to_writer(&mut output).unwrap();
     assert_eq!(output, expected);

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -200,7 +200,7 @@ fn test_flatten_indexed_sourcemap_with_ignore_list() {
         ism.flatten()
             .unwrap()
             .ignore_list()
-            .cloned()
+            .copied()
             .collect::<Vec<u32>>(),
         vec![1]
     );

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -158,3 +158,50 @@ fn test_indexed_sourcemap_for_react_native() {
     let ism = SourceMapIndex::from_reader(input).unwrap();
     assert!(ism.is_for_ram_bundle());
 }
+
+#[test]
+fn test_flatten_indexed_sourcemap_with_ignore_list() {
+    let input: &[_] = br#"{
+        "version": 3,
+        "file": "bla",
+        "sections": [
+            {
+                "offset": {
+                    "line": 0,
+                    "column": 0
+                },
+                "map": {
+                    "version":3,
+                    "sources":["file1.js"],
+                    "names":["add","a","b"],
+                    "mappings":"AAAA,QAASA,KAAIC,EAAGC,GACf,YACA,OAAOD,GAAIC",
+                    "file":"file1.min.js"
+                }
+            },
+            {
+                "offset": {
+                    "line": 1,
+                    "column": 0
+                },
+                "map": {
+                    "version":3,
+                    "sources":["file2.js"],
+                    "names":["multiply","a","b","divide","add","c","e","Raven","captureException"],
+                    "mappings":"AAAA,QAASA,UAASC,EAAGC,GACpB,YACA,OAAOD,GAAIC,EAEZ,QAASC,QAAOF,EAAGC,GAClB,YACA,KACC,MAAOF,UAASI,IAAIH,EAAGC,GAAID,EAAGC,GAAKG,EAClC,MAAOC,GACRC,MAAMC,iBAAiBF",
+                    "file":"file2.min.js",
+                    "ignoreList": [0]
+                }
+            }
+        ]
+    }"#;
+
+    let ism = SourceMapIndex::from_reader(input).unwrap();
+    assert_eq!(
+        ism.flatten()
+            .unwrap()
+            .ignore_list()
+            .cloned()
+            .collect::<Vec<u32>>(),
+        vec![1]
+    );
+}


### PR DESCRIPTION
Sourcemaps can now specify an `ignoreList`[0], a list of indexes into sources for which those sources should be shown as ignored in dev tools, for example as collapsed stack frames in program stacks.

This adds the list to the SourceMap structure but only includes it in serialized output when it’s non-zero. Open to feedback.

Added a test to exercise this through flattening indexed source maps into a regular map with updated source positions.

[0] https://tc39.es/source-map/#source-map-format