### PR TITLE
feat: Read debug IDs from debugId field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes and improvements
+
+- Debug IDs can be read from the "debugId" field in addition to "debug_id" (#97) by @loewenheim.
+
 ## 9.0.0
 
 ### Various fixes and improvements

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -52,7 +52,7 @@ pub struct RawSourceMap {
     pub x_metro_module_paths: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_facebook_sources: FacebookSources,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "debugId")]
     pub debug_id: Option<DebugId>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1319,6 +1319,21 @@ mod tests {
     }
 
     #[test]
+    fn test_debugid_alias() {
+        let input: &[_] = br#"{
+         "version":3,
+         "sources":["coolstuff.js"],
+         "names":["x","alert"],
+         "mappings":"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
+         "debugId":"00000000-0000-0000-0000-000000000000"
+     }"#;
+
+        let sm = SourceMap::from_slice(input).unwrap();
+
+        assert_eq!(sm.debug_id, Some(DebugId::default()));
+    }
+
+    #[test]
     fn test_adjust_mappings_injection() {
         // A test that `adjust_mappings` does what it's supposed to for debug id injection.
         //


### PR DESCRIPTION
This partially implements #96. The debug id will still be serialized as `"debug_id"`, but can now additionally be read from `"debugId"`.