### PR TITLE
fix: Resolve conflict between "debugId" and "debug_id"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes & improvements
+
+- Fixed an error when deserializing sourcemaps with
+  both `"debugId"` and `"debug_id"` keys (#100) by @loewenheim
+
 ## 9.1.0
 
 ### Various fixes & improvements

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -253,7 +253,9 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 
     let mut sm = SourceMap::new(file, tokens, names, sources, source_content);
     sm.set_source_root(rsm.source_root);
-    sm.set_debug_id(rsm.debug_id);
+    // Use debug_id_old (from "debug_id" key) only if debug_id
+    // from ( "debugId" key) is unset
+    sm.set_debug_id(rsm.debug_id.or(rsm.debug_id_old));
     if let Some(ignore_list) = rsm.ignore_list {
         for idx in ignore_list {
             sm.add_to_ignore_list(idx);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -179,6 +179,7 @@ impl Encodable for SourceMap {
             x_metro_module_paths: None,
             x_facebook_sources: None,
             debug_id: self.get_debug_id(),
+            debug_id_old: None,
         }
     }
 }
@@ -213,6 +214,7 @@ impl Encodable for SourceMapIndex {
             x_metro_module_paths: None,
             x_facebook_sources: None,
             debug_id: None,
+            debug_id_old: None,
         }
     }
 }

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -58,7 +58,7 @@ pub struct RawSourceMap {
     pub debug_id: Option<DebugId>,
     // This field only exists to be able to deserialize from "debug_id" keys
     // if "debugId" is unset.
-    #[serde(skip_serializing, rename = "debug_id")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "debug_id")]
     pub debug_id_old: Option<DebugId>,
 }
 

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -54,8 +54,12 @@ pub struct RawSourceMap {
     pub x_metro_module_paths: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_facebook_sources: FacebookSources,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "debugId")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "debugId")]
     pub debug_id: Option<DebugId>,
+    // This field only exists to be able to deserialize from "debug_id" keys
+    // if "debugId" is unset.
+    #[serde(skip_serializing, rename = "debug_id")]
+    pub debug_id_old: Option<DebugId>,
 }
 
 #[derive(Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1340,6 +1340,7 @@ mod tests {
          "sources":["coolstuff.js"],
          "names":["x","alert"],
          "mappings":"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
+         "debug_id": "11111111-1111-1111-1111-111111111111",
          "debugId":"00000000-0000-0000-0000-000000000000"
      }"#;
 


### PR DESCRIPTION
Using an alias produces an error when both fields are set. The intended behavior is to only read from `"debug_id"` if `"debugId"` is not present. We now encode this logic explicitly by deserializing both and choosing manually.