### PR TITLE
fix: Prefer debug_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes & improvements
+
+- Prefer `"debug_id"` for sourcemap debug IDs (#101) by @loewenheim
+
+
 ## 9.1.1
 
 ### Various fixes & improvements

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -253,9 +253,9 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 
     let mut sm = SourceMap::new(file, tokens, names, sources, source_content);
     sm.set_source_root(rsm.source_root);
-    // Use debug_id_old (from "debug_id" key) only if debug_id
-    // from ( "debugId" key) is unset
-    sm.set_debug_id(rsm.debug_id.or(rsm.debug_id_old));
+    // Use _debug_id_new (from "debugId" key) only if debug_id
+    // from ( "debug_id" key) is unset
+    sm.set_debug_id(rsm.debug_id.or(rsm._debug_id_new));
     if let Some(ignore_list) = rsm.ignore_list {
         for idx in ignore_list {
             sm.add_to_ignore_list(idx);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -179,7 +179,7 @@ impl Encodable for SourceMap {
             x_metro_module_paths: None,
             x_facebook_sources: None,
             debug_id: self.get_debug_id(),
-            debug_id_old: None,
+            _debug_id_new: None,
         }
     }
 }
@@ -214,7 +214,7 @@ impl Encodable for SourceMapIndex {
             x_metro_module_paths: None,
             x_facebook_sources: None,
             debug_id: None,
-            debug_id_old: None,
+            _debug_id_new: None,
         }
     }
 }

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -54,12 +54,12 @@ pub struct RawSourceMap {
     pub x_metro_module_paths: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_facebook_sources: FacebookSources,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "debugId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub debug_id: Option<DebugId>,
-    // This field only exists to be able to deserialize from "debug_id" keys
-    // if "debugId" is unset.
-    #[serde(skip_serializing_if = "Option::is_none", rename = "debug_id")]
-    pub debug_id_old: Option<DebugId>,
+    // This field only exists to be able to deserialize from "debugId" keys
+    // if "debug_id" is unset.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "debugId")]
+    pub(crate) _debug_id_new: Option<DebugId>,
 }
 
 #[derive(Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1340,8 +1340,8 @@ mod tests {
          "sources":["coolstuff.js"],
          "names":["x","alert"],
          "mappings":"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
-         "debug_id": "11111111-1111-1111-1111-111111111111",
-         "debugId":"00000000-0000-0000-0000-000000000000"
+         "debug_id":"00000000-0000-0000-0000-000000000000",
+         "debugId": "11111111-1111-1111-1111-111111111111"
      }"#;
 
         let sm = SourceMap::from_slice(input).unwrap();


### PR DESCRIPTION
#100 overzealously switched the default key from debug_id to debugId. While both should be supported, we should default to the current debug_id for now and make the switch in a considered manner.