### PR TITLE
Fix Hermes get original function name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 target
 Cargo.lock
+.idea

--- a/src/hermes.rs
+++ b/src/hermes.rs
@@ -110,10 +110,11 @@ impl SourceMapHermes {
         // https://github.com/facebook/metro/blob/63b523eb20e7bdf62018aeaf195bb5a3a1a67f36/packages/metro-symbolicate/src/SourceMetadataMapConsumer.js#L204-L231
         // Mappings use 1-based index for lines, and 0-based index for cols, as seen here:
         // https://github.com/facebook/metro/blob/f2d80cebe66d3c64742f67259f41da26e83a0d8d/packages/metro/src/Server/symbolicate.js#L58-L60
-        let (_mapping_idx, mapping) =
-            greatest_lower_bound(&function_map.mappings, &(token.get_src_line() + 1, token.get_src_col()), |o| {
-                (o.line, o.column)
-            })?;
+        let (_mapping_idx, mapping) = greatest_lower_bound(
+            &function_map.mappings,
+            &(token.get_src_line() + 1, token.get_src_col()),
+            |o| (o.line, o.column),
+        )?;
         function_map
             .names
             .get(mapping.name_index as usize)

--- a/src/hermes.rs
+++ b/src/hermes.rs
@@ -108,8 +108,10 @@ impl SourceMapHermes {
 
         // Find the closest mapping, just like here:
         // https://github.com/facebook/metro/blob/63b523eb20e7bdf62018aeaf195bb5a3a1a67f36/packages/metro-symbolicate/src/SourceMetadataMapConsumer.js#L204-L231
+        // Mappings use 1-based index for lines, and 0-based index for cols, as seen here:
+        // https://github.com/facebook/metro/blob/f2d80cebe66d3c64742f67259f41da26e83a0d8d/packages/metro/src/Server/symbolicate.js#L58-L60
         let (_mapping_idx, mapping) =
-            greatest_lower_bound(&function_map.mappings, &token.get_src(), |o| {
+            greatest_lower_bound(&function_map.mappings, &(token.get_src_line() + 1, token.get_src_col()), |o| {
                 (o.line, o.column)
             })?;
         function_map

--- a/src/ram_bundle.rs
+++ b/src/ram_bundle.rs
@@ -416,7 +416,7 @@ impl<'a> SplitRamBundleModuleIter<'a> {
     }
 }
 
-impl<'a> Iterator for SplitRamBundleModuleIter<'a> {
+impl Iterator for SplitRamBundleModuleIter<'_> {
     type Item = Result<(String, SourceView, SourceMap)>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -457,8 +457,7 @@ pub fn split_ram_bundle<'a>(
 pub fn is_ram_bundle_slice(slice: &[u8]) -> bool {
     slice
         .pread_with::<RamBundleHeader>(0, scroll::LE)
-        .ok()
-        .map_or(false, |x| x.is_valid_magic())
+        .ok().is_some_and(|x| x.is_valid_magic())
 }
 
 /// Returns "true" if the given path points to the startup file of a file RAM bundle

--- a/src/ram_bundle.rs
+++ b/src/ram_bundle.rs
@@ -457,7 +457,8 @@ pub fn split_ram_bundle<'a>(
 pub fn is_ram_bundle_slice(slice: &[u8]) -> bool {
     slice
         .pread_with::<RamBundleHeader>(0, scroll::LE)
-        .ok().is_some_and(|x| x.is_valid_magic())
+        .ok()
+        .is_some_and(|x| x.is_valid_magic())
 }
 
 /// Returns "true" if the given path points to the startup file of a file RAM bundle

--- a/tests/test_hermes.rs
+++ b/tests/test_hermes.rs
@@ -19,6 +19,12 @@ fn test_react_native_hermes() {
         ("input.js", 2, 0, None)
     );
     assert_eq!(sm.get_original_function_name(11857), Some("<global>"));
+
+    assert_eq!(
+        sm.lookup_token(0, 11947).unwrap().to_tuple(),
+        ("module.js", 1, 4, None)
+    );
+    assert_eq!(sm.get_original_function_name(11947), Some("foo"));
 }
 
 #[test]


### PR DESCRIPTION
The utility to get the original function name of a given token is slightly incorrect. 
The mappings included in the map file, for whatever reason are 1-based indexed for the lines, and 0-based for the columns.

Given that we were doing the lookup based on both 0-based indexes, sometimes the lookup was incorrect as we are pointing to line before, and in cases where the token is the very first line of the function, it may return an invalid function name (only when the column ends up being also before the `function` keyword)

I added a test case based on the testdata that we have today that points to the `throw` token of the module.js file, which is before the `function` in terms of the column, and that showed the error.

Also, here we can see that facebook uses 1-based for lines and 0-based for cols: https://github.com/facebook/metro/blob/f2d80cebe66d3c64742f67259f41da26e83a0d8d/packages/metro/src/Server/symbolicate.js#L58-L60