### PR TITLE
ref(tests): Move tests under `cfg(test)`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -229,25 +229,30 @@ impl Encodable for DecodedMap {
     }
 }
 
-#[test]
-fn test_encode_rmi() {
-    fn encode(indices: &[usize]) -> String {
-        let mut out = vec![];
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        // Fill with zeros while testing
-        let mut data = vec![0; 256];
+    #[test]
+    fn test_encode_rmi() {
+        fn encode(indices: &[usize]) -> String {
+            let mut out = vec![];
 
-        let bits = data.view_bits_mut::<Lsb0>();
-        for &i in indices {
-            bits.set(i, true);
+            // Fill with zeros while testing
+            let mut data = vec![0; 256];
+
+            let bits = data.view_bits_mut::<Lsb0>();
+            for &i in indices {
+                bits.set(i, true);
+            }
+
+            encode_rmi(&mut out, &data);
+            String::from_utf8(out).unwrap()
         }
 
-        encode_rmi(&mut out, &data);
-        String::from_utf8(out).unwrap()
+        // This is 0-based index
+        assert_eq!(encode(&[12]), "AAB");
+        assert_eq!(encode(&[5]), "g");
+        assert_eq!(encode(&[0, 11]), "Bg");
     }
-
-    // This is 0-based index
-    assert_eq!(encode(&[12]), "AAB");
-    assert_eq!(encode(&[5]), "g");
-    assert_eq!(encode(&[0, 11]), "Bg");
 }

--- a/src/js_identifiers.rs
+++ b/src/js_identifiers.rs
@@ -63,20 +63,23 @@ pub fn get_javascript_token(source_line: &str) -> Option<&str> {
     }
 }
 
-#[test]
-fn test_is_valid_javascript_identifier() {
-    // assert_eq!(is_valid_javascript_identifier("foo 123"));
-    assert!(is_valid_javascript_identifier("foo_$123"));
-    assert!(!is_valid_javascript_identifier(" foo"));
-    assert!(!is_valid_javascript_identifier("foo "));
-    assert!(!is_valid_javascript_identifier("[123]"));
-    assert!(!is_valid_javascript_identifier("foo.bar"));
-    // Should these pass?
-    // assert!(is_valid_javascript_identifier("foo [bar]"));
-    // assert!(is_valid_javascript_identifier("foo[bar]"));
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    assert_eq!(get_javascript_token("foo "), Some("foo"));
-    assert_eq!(get_javascript_token("f _hi"), Some("f"));
-    assert_eq!(get_javascript_token("foo.bar"), Some("foo"));
-    assert_eq!(get_javascript_token("[foo,bar]"), None);
+    #[test]
+    fn test_is_valid_javascript_identifier() {
+        // assert_eq!(is_valid_javascript_identifier("foo 123"));
+        assert!(is_valid_javascript_identifier("foo_$123"));
+        assert!(!is_valid_javascript_identifier(" foo"));
+        assert!(!is_valid_javascript_identifier("foo "));
+        assert!(!is_valid_javascript_identifier("[123]"));
+        assert!(!is_valid_javascript_identifier("foo.bar"));
+        // Should these pass?
+        // assert!(is_valid_javascript_identifier("foo [bar]"));
+        assert_eq!(get_javascript_token("foo "), Some("foo"));
+        assert_eq!(get_javascript_token("f _hi"), Some("f"));
+        assert_eq!(get_javascript_token("foo.bar"), Some("foo"));
+        assert_eq!(get_javascript_token("[foo,bar]"), None);
+    }
 }

--- a/src/sourceview.rs
+++ b/src/sourceview.rs
@@ -314,48 +314,53 @@ impl SourceView {
     }
 }
 
-#[test]
-#[allow(clippy::cognitive_complexity)]
-fn test_minified_source_view() {
-    let view = SourceView::new("a\nb\nc".into());
-    assert_eq!(view.get_line(0), Some("a"));
-    assert_eq!(view.get_line(0), Some("a"));
-    assert_eq!(view.get_line(2), Some("c"));
-    assert_eq!(view.get_line(1), Some("b"));
-    assert_eq!(view.get_line(3), None);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    assert_eq!(view.line_count(), 3);
+    #[test]
+    #[allow(clippy::cognitive_complexity)]
+    fn test_minified_source_view() {
+        let view = SourceView::new("a\nb\nc".into());
+        assert_eq!(view.get_line(0), Some("a"));
+        assert_eq!(view.get_line(0), Some("a"));
+        assert_eq!(view.get_line(2), Some("c"));
+        assert_eq!(view.get_line(1), Some("b"));
+        assert_eq!(view.get_line(3), None);
 
-    let view = SourceView::new("a\r\nb\r\nc".into());
-    assert_eq!(view.get_line(0), Some("a"));
-    assert_eq!(view.get_line(0), Some("a"));
-    assert_eq!(view.get_line(2), Some("c"));
-    assert_eq!(view.get_line(1), Some("b"));
-    assert_eq!(view.get_line(3), None);
+        assert_eq!(view.line_count(), 3);
 
-    assert_eq!(view.line_count(), 3);
+        let view = SourceView::new("a\r\nb\r\nc".into());
+        assert_eq!(view.get_line(0), Some("a"));
+        assert_eq!(view.get_line(0), Some("a"));
+        assert_eq!(view.get_line(2), Some("c"));
+        assert_eq!(view.get_line(1), Some("b"));
+        assert_eq!(view.get_line(3), None);
 
-    let view = SourceView::new("abc👌def\nblah".into());
-    assert_eq!(view.get_line_slice(0, 0, 3), Some("abc"));
-    assert_eq!(view.get_line_slice(0, 3, 1), Some("👌"));
-    assert_eq!(view.get_line_slice(0, 3, 2), Some("👌"));
-    assert_eq!(view.get_line_slice(0, 3, 3), Some("👌d"));
-    assert_eq!(view.get_line_slice(0, 0, 4), Some("abc👌"));
-    assert_eq!(view.get_line_slice(0, 0, 5), Some("abc👌"));
-    assert_eq!(view.get_line_slice(0, 0, 6), Some("abc👌d"));
-    assert_eq!(view.get_line_slice(1, 0, 4), Some("blah"));
-    assert_eq!(view.get_line_slice(1, 0, 5), None);
-    assert_eq!(view.get_line_slice(1, 0, 12), None);
+        assert_eq!(view.line_count(), 3);
 
-    let view = SourceView::new("a\nb\nc\n".into());
-    assert_eq!(view.get_line(0), Some("a"));
-    assert_eq!(view.get_line(1), Some("b"));
-    assert_eq!(view.get_line(2), Some("c"));
-    assert_eq!(view.get_line(3), Some(""));
-    assert_eq!(view.get_line(4), None);
+        let view = SourceView::new("abc👌def\nblah".into());
+        assert_eq!(view.get_line_slice(0, 0, 3), Some("abc"));
+        assert_eq!(view.get_line_slice(0, 3, 1), Some("👌"));
+        assert_eq!(view.get_line_slice(0, 3, 2), Some("👌"));
+        assert_eq!(view.get_line_slice(0, 3, 3), Some("👌d"));
+        assert_eq!(view.get_line_slice(0, 0, 4), Some("abc👌"));
+        assert_eq!(view.get_line_slice(0, 0, 5), Some("abc👌"));
+        assert_eq!(view.get_line_slice(0, 0, 6), Some("abc👌d"));
+        assert_eq!(view.get_line_slice(1, 0, 4), Some("blah"));
+        assert_eq!(view.get_line_slice(1, 0, 5), None);
+        assert_eq!(view.get_line_slice(1, 0, 12), None);
 
-    fn is_send<T: Send>() {}
-    fn is_sync<T: Sync>() {}
-    is_send::<SourceView>();
-    is_sync::<SourceView>();
+        let view = SourceView::new("a\nb\nc\n".into());
+        assert_eq!(view.get_line(0), Some("a"));
+        assert_eq!(view.get_line(1), Some("b"));
+        assert_eq!(view.get_line(2), Some("c"));
+        assert_eq!(view.get_line(3), Some(""));
+        assert_eq!(view.get_line(4), None);
+
+        fn is_send<T: Send>() {}
+        fn is_sync<T: Sync>() {}
+        is_send::<SourceView>();
+        is_sync::<SourceView>();
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -141,87 +141,94 @@ pub fn greatest_lower_bound<'a, T, K: Ord, F: Fn(&'a T) -> K>(
     slice.get(idx).map(|res| (idx, res))
 }
 
-#[test]
-fn test_is_abs_path() {
-    assert!(is_abs_path("C:\\foo.txt"));
-    assert!(is_abs_path("d:/foo.txt"));
-    assert!(!is_abs_path("foo.txt"));
-    assert!(is_abs_path("/foo.txt"));
-    assert!(is_abs_path("/"));
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_split_path() {
-    assert_eq!(split_path("/foo/bar/baz"), &["", "/foo", "/bar", "/baz"]);
-}
+    #[test]
+    fn test_is_abs_path() {
+        assert!(is_abs_path("C:\\foo.txt"));
+        assert!(is_abs_path("d:/foo.txt"));
+        assert!(!is_abs_path("foo.txt"));
+        assert!(is_abs_path("/foo.txt"));
+        assert!(is_abs_path("/"));
+    }
 
-#[test]
-fn test_find_common_prefix() {
-    let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah"].into_iter());
-    assert_eq!(rv, Some("/foo/bar/baz".into()));
+    #[test]
+    fn test_split_path() {
+        assert_eq!(split_path("/foo/bar/baz"), &["", "/foo", "/bar", "/baz"]);
+    }
 
-    let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/meh"].into_iter());
-    assert_eq!(rv, None);
+    #[test]
+    fn test_find_common_prefix() {
+        let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah"].into_iter());
+        assert_eq!(rv, Some("/foo/bar/baz".into()));
 
-    let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/foo"].into_iter());
-    assert_eq!(rv, Some("/foo".into()));
+        let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/meh"].into_iter());
+        assert_eq!(rv, None);
 
-    let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "foo"].into_iter());
-    assert_eq!(rv, Some("/foo/bar/baz".into()));
+        let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/foo"].into_iter());
+        assert_eq!(rv, Some("/foo".into()));
 
-    let rv =
-        find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/blah", "foo"].into_iter());
-    assert_eq!(rv, None);
+        let rv = find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "foo"].into_iter());
+        assert_eq!(rv, Some("/foo/bar/baz".into()));
 
-    let rv =
-        find_common_prefix(vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/blah", "foo"].into_iter());
-    assert_eq!(rv, None);
-}
+        let rv = find_common_prefix(
+            vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/blah", "foo"].into_iter(),
+        );
+        assert_eq!(rv, None);
 
-#[test]
-fn test_make_relative_path() {
-    assert_eq!(
-        &make_relative_path("/foo/bar/baz.js", "/foo/bar/baz.map"),
-        "baz.map"
-    );
-    assert_eq!(
-        &make_relative_path("/foo/bar/.", "/foo/bar/baz.map"),
-        "baz.map"
-    );
-    assert_eq!(
-        &make_relative_path("/foo/bar/baz.js", "/foo/baz.map"),
-        "../baz.map"
-    );
-    assert_eq!(&make_relative_path("foo.txt", "foo.js"), "foo.js");
-    assert_eq!(&make_relative_path("blah/foo.txt", "foo.js"), "../foo.js");
-}
+        let rv = find_common_prefix(
+            vec!["/foo/bar/baz", "/foo/bar/baz/blah", "/blah", "foo"].into_iter(),
+        );
+        assert_eq!(rv, None);
+    }
 
-#[test]
-fn test_greatest_lower_bound() {
-    let cmp = |&(i, _id)| i;
+    #[test]
+    fn test_make_relative_path() {
+        assert_eq!(
+            &make_relative_path("/foo/bar/baz.js", "/foo/bar/baz.map"),
+            "baz.map"
+        );
+        assert_eq!(
+            &make_relative_path("/foo/bar/.", "/foo/bar/baz.map"),
+            "baz.map"
+        );
+        assert_eq!(
+            &make_relative_path("/foo/bar/baz.js", "/foo/baz.map"),
+            "../baz.map"
+        );
+        assert_eq!(&make_relative_path("foo.txt", "foo.js"), "foo.js");
+        assert_eq!(&make_relative_path("blah/foo.txt", "foo.js"), "../foo.js");
+    }
 
-    let haystack = vec![(1, 1)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 1));
-    assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
+    #[test]
+    fn test_greatest_lower_bound() {
+        let cmp = |&(i, _id)| i;
 
-    let haystack = vec![(1, 1), (1, 2)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 2));
-    assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
+        let haystack = vec![(1, 1)];
+        assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+        assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 1));
+        assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 
-    let haystack = vec![(1, 1), (1, 2), (1, 3)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 3));
-    assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
+        let haystack = vec![(1, 1), (1, 2)];
+        assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+        assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 2));
+        assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 
-    let haystack = vec![(1, 1), (1, 2), (1, 3), (1, 4)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 4));
-    assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
+        let haystack = vec![(1, 1), (1, 2), (1, 3)];
+        assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+        assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 3));
+        assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
 
-    let haystack = vec![(1, 1), (1, 2), (1, 3), (1, 4), (1, 5)];
-    assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
-    assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 5));
-    assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
+        let haystack = vec![(1, 1), (1, 2), (1, 3), (1, 4)];
+        assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+        assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 4));
+        assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
+
+        let haystack = vec![(1, 1), (1, 2), (1, 3), (1, 4), (1, 5)];
+        assert_eq!(greatest_lower_bound(&haystack, &1, cmp).unwrap().1, &(1, 1));
+        assert_eq!(greatest_lower_bound(&haystack, &2, cmp).unwrap().1, &(1, 5));
+        assert_eq!(greatest_lower_bound(&haystack, &0, cmp), None);
+    }
 }

--- a/src/vlq.rs
+++ b/src/vlq.rs
@@ -328,28 +328,33 @@ pub(crate) fn encode_vlq(out: &mut String, num: i64) {
     }
 }
 
-#[test]
-fn test_vlq_decode() {
-    let rv = parse_vlq_segment("AAAA").unwrap();
-    assert_eq!(rv, vec![0, 0, 0, 0]);
-    let rv = parse_vlq_segment("GAAIA").unwrap();
-    assert_eq!(rv, vec![3, 0, 0, 4, 0]);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_vlq_encode() {
-    let rv = generate_vlq_segment(&[0, 0, 0, 0]).unwrap();
-    assert_eq!(rv.as_str(), "AAAA");
-    let rv = generate_vlq_segment(&[3, 0, 0, 4, 0]).unwrap();
-    assert_eq!(rv.as_str(), "GAAIA");
-}
+    #[test]
+    fn test_vlq_decode() {
+        let rv = parse_vlq_segment("AAAA").unwrap();
+        assert_eq!(rv, vec![0, 0, 0, 0]);
+        let rv = parse_vlq_segment("GAAIA").unwrap();
+        assert_eq!(rv, vec![3, 0, 0, 4, 0]);
+    }
 
-#[test]
-fn test_overflow() {
-    match parse_vlq_segment("00000000000000") {
-        Err(Error::VlqOverflow) => {}
-        e => {
-            panic!("Unexpeted result: {:?}", e);
+    #[test]
+    fn test_vlq_encode() {
+        let rv = generate_vlq_segment(&[0, 0, 0, 0]).unwrap();
+        assert_eq!(rv.as_str(), "AAAA");
+        let rv = generate_vlq_segment(&[3, 0, 0, 4, 0]).unwrap();
+        assert_eq!(rv.as_str(), "GAAIA");
+    }
+
+    #[test]
+    fn test_overflow() {
+        match parse_vlq_segment("00000000000000") {
+            Err(Error::VlqOverflow) => {}
+            e => {
+                panic!("Unexpeted result: {:?}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
This way, tests are not compiled into binaries except when testing.