### PR TITLE
feat: Add `debug_id` field to `SourceMapIndex`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -214,7 +214,8 @@ impl Encodable for SourceMapIndex {
             x_metro_module_paths: None,
             x_facebook_sources: None,
             debug_id: None,
-            _debug_id_new: None,
+            // Put the debug ID on _debug_id_new to serialize it to the debugId field.
+            _debug_id_new: self.debug_id(),
         }
     }
 }
@@ -254,5 +255,62 @@ mod tests {
         assert_eq!(encode(&[12]), "AAB");
         assert_eq!(encode(&[5]), "g");
         assert_eq!(encode(&[0, 11]), "Bg");
+    }
+
+    #[test]
+    fn test_encode_sourcemap_index_no_debug_id() {
+        let smi = SourceMapIndex::new(Some("test.js".into()), vec![]);
+        let raw = smi.as_raw_sourcemap();
+
+        assert_eq!(
+            raw,
+            RawSourceMap {
+                version: Some(3),
+                file: Some("test.js".into()),
+                sources: None,
+                source_root: None,
+                sources_content: None,
+                sections: Some(vec![]),
+                names: None,
+                range_mappings: None,
+                mappings: None,
+                ignore_list: None,
+                x_facebook_offsets: None,
+                x_metro_module_paths: None,
+                x_facebook_sources: None,
+                debug_id: None,
+                _debug_id_new: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_encode_sourcemap_index_debug_id() {
+        const DEBUG_ID: &str = "0123456789abcdef0123456789abcdef";
+
+        let smi = SourceMapIndex::new(Some("test.js".into()), vec![])
+            .with_debug_id(Some(DEBUG_ID.parse().expect("valid debug id")));
+
+        let raw = smi.as_raw_sourcemap();
+        assert_eq!(
+            raw,
+            RawSourceMap {
+                version: Some(3),
+                file: Some("test.js".into()),
+                sources: None,
+                source_root: None,
+                sources_content: None,
+                sections: Some(vec![]),
+                names: None,
+                range_mappings: None,
+                mappings: None,
+                ignore_list: None,
+                x_facebook_offsets: None,
+                x_metro_module_paths: None,
+                x_facebook_sources: None,
+                debug_id: None,
+                _debug_id_new: Some(DEBUG_ID.parse().expect("valid debug id")),
+            }
+        );
     }
 }

--- a/src/hermes.rs
+++ b/src/hermes.rs
@@ -12,14 +12,14 @@ use std::ops::{Deref, DerefMut};
 /// These are starting locations of scopes.
 /// The `name_index` represents the index into the `HermesFunctionMap.names` vec,
 /// which represents the function names/scopes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HermesScopeOffset {
     line: u32,
     column: u32,
     name_index: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HermesFunctionMap {
     names: Vec<String>,
     mappings: Vec<HermesScopeOffset>,
@@ -27,7 +27,7 @@ pub struct HermesFunctionMap {
 
 /// Represents a `react-native`-style SourceMap, which has additional scope
 /// information embedded.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SourceMapHermes {
     pub(crate) sm: SourceMap,
     // There should be one `HermesFunctionMap` per each `sources` entry in the main SourceMap.

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -3,20 +3,20 @@ use serde::de::IgnoredAny;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct RawSectionOffset {
     pub line: u32,
     pub column: u32,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct RawSection {
     pub offset: RawSectionOffset,
     pub url: Option<String>,
     pub map: Option<Box<RawSourceMap>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct FacebookScopeMapping {
     pub names: Vec<String>,
     pub mappings: String,
@@ -28,7 +28,7 @@ pub struct FacebookScopeMapping {
 // See the decoder in `hermes.rs` for details.
 pub type FacebookSources = Option<Vec<Option<Vec<FacebookScopeMapping>>>>;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct RawSourceMap {
     pub version: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/sourceview.rs
+++ b/src/sourceview.rs
@@ -151,6 +151,12 @@ impl fmt::Debug for SourceView {
     }
 }
 
+impl PartialEq for SourceView {
+    fn eq(&self, other: &Self) -> bool {
+        self.source == other.source
+    }
+}
+
 impl SourceView {
     /// Creates an optimized view of a given source.
     pub fn new(source: Arc<str>) -> SourceView {


### PR DESCRIPTION
Also, add support for encoding and decoding the new `debug_id` field, and add tests.

In order to be able to more thoroughly test encoding/decoding, this code adds `PartialEq` and `Debug` implementations to some structs which were lacking it previously.

Closes #113