### PR TITLE
perf: Make `SourceMapIndex::flatten` more efficient

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1228,6 +1228,14 @@ impl SourceMapIndex {
                 }
             };
 
+            for (source, contents) in map.sources().zip(map.source_contents()) {
+                let src_id = builder.add_source(source);
+
+                if let Some(contents) = contents {
+                    builder.set_source_contents(src_id, Some(contents));
+                }
+            }
+
             for token in map.tokens() {
                 let dst_col = if token.get_dst_line() == 0 {
                     token.get_dst_col() + off_col
@@ -1243,12 +1251,7 @@ impl SourceMapIndex {
                     token.get_name(),
                     token.is_range(),
                 );
-                if token.get_source().is_some() && !builder.has_source_contents(raw.src_id) {
-                    builder.set_source_contents(
-                        raw.src_id,
-                        map.get_source_contents(token.get_src_id()),
-                    );
-                }
+
                 if map.ignore_list.contains(&token.get_src_id()) {
                     builder.add_to_ignore_list(raw.src_id);
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1242,13 +1242,17 @@ impl SourceMapIndex {
                 } else {
                     token.get_dst_col()
                 };
-                let raw = builder.add(
+
+                let src_id = token.get_source().map(|source| builder.add_source(source));
+                let name_id = token.get_name().map(|name| builder.add_name(name));
+
+                let raw = builder.add_raw(
                     token.get_dst_line() + off_line,
                     dst_col,
                     token.get_src_line(),
                     token.get_src_col(),
-                    token.get_source(),
-                    token.get_name(),
+                    src_id,
+                    name_id,
                     token.is_range(),
                 );
 


### PR DESCRIPTION
We can move sources and source contents beforehand, assuming we will use all sources anyway. 