### PR TITLE
perf: Make `adjust_mappings` faster by reducing the type size

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -965,7 +965,7 @@ impl SourceMap {
         /// Turns a list of tokens into a list of ranges, using the provided `key` function to determine the order of the tokens.
         #[allow(clippy::ptr_arg)]
         fn create_ranges(
-            tokens: &mut Vec<RawToken>,
+            tokens: &mut [RawToken],
             key: fn(&RawToken) -> (u32, u32),
         ) -> Vec<Range<'_>> {
             tokens.sort_unstable_by_key(key);

--- a/src/types.rs
+++ b/src/types.rs
@@ -970,7 +970,7 @@ impl SourceMap {
         ) -> Vec<Range<'_>> {
             tokens.sort_unstable_by_key(key);
 
-            let mut token_iter = tokens.iter_mut().peekable();
+            let mut token_iter = tokens.iter().peekable();
             let mut ranges = Vec::new();
 
             while let Some(t) = token_iter.next() {


### PR DESCRIPTION
The size of `Range` is now 24 bytes instead of 44 bytes. `RawToken` is 28 bytes, but dereferencing it is a trivial memory move rather than an allocation.


I'll report the numbers within this week.