### PR TITLE
perf: Avoid `clone` in `adjust_mappings` when possible

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -963,7 +963,6 @@ impl SourceMap {
         }
 
         /// Turns a list of tokens into a list of ranges, using the provided `key` function to determine the order of the tokens.
-        #[allow(clippy::ptr_arg)]
         fn create_ranges(
             tokens: &mut [RawToken],
             key: fn(&RawToken) -> (u32, u32),


### PR DESCRIPTION
Related: https://github.com/getsentry/rust-sourcemap/pull/124#discussion_r2101843799